### PR TITLE
Fix async chat endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -100,11 +100,11 @@ class ChatRequest(BaseModel):
 @app.post("/api/chat")
 async def chat(request: ChatRequest):
     try:
-        response = openai.ChatCompletion.create(
+        response = await openai.ChatCompletion.acreate(
             model="gpt-4o",
             messages=request.messages,
-            temperature=0.7
+            temperature=0.7,
         )
-        return response['choices'][0]['message']
+        return response["choices"][0]["message"]
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -17,3 +17,19 @@ def test_pdf_generation():
     resp = client.post('/pdf', json=data)
     assert resp.status_code == 200
     assert resp.headers['content-type'] == 'application/zip'
+
+def test_chat_endpoint(monkeypatch):
+    async def fake_acreate(*args, **kwargs):
+        return {"choices": [{"message": {"role": "assistant", "content": "hi"}}]}
+
+    monkeypatch.setattr(
+        "backend.main.openai.ChatCompletion.acreate",
+        fake_acreate,
+    )
+
+    resp = client.post(
+        "/api/chat",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"role": "assistant", "content": "hi"}


### PR DESCRIPTION
## Summary
- call `openai.ChatCompletion.acreate` in `/api/chat`
- test `/api/chat` with a mocked response

## Testing
- `pip install -r backend/requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68882d4d16608332af35b0ee44282ebb