### PR TITLE
docs: add test dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ cd frontend && npm install
 npm test -- --watchAll=false
 ```
 
+### Installing Test Dependencies
+
+Install Python packages for the micro‑service and Node packages for the Next.js front‑end before running tests.
+
+```bash
+# Python packages
+pip install -r requirements.txt
+
+# Node packages
+cd frontend && npm install
+```
+
 ### License
 
 MIT – see `LICENSE.md`.


### PR DESCRIPTION
## Summary
- document how to install Python and Node dependencies needed for running tests

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_b_68882d5d714483328a7a1d15171c9420