### PR TITLE
docs: clarify local setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ cd PODrafter
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pytest
+# start the server (requires OPENAI_API_KEY)
+uvicorn backend.main:app --reload
 # frontend
 cd frontend && npm install
 npm test -- --watchAll=false
+npm run dev
 ```
 
 ### Installing Test Dependencies


### PR DESCRIPTION
## Summary
- update README Quick Start with instructions to set `OPENAI_API_KEY`
- show how to run the backend and front-end servers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68882ed9eef48332af31dbc393eaabdf