### PR TITLE
Configure API base URL via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for local development
+# Base URL for the backend API used by the SvelteKit frontend
+# e.g. http://localhost:8000 or https://your-deploy.com
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,9 +19,10 @@
     const userMessage = input;
     input = '';
 
-    // 3️⃣ Call your Fly.io backend
+    // 3️⃣ Call your backend
+    const baseUrl = import.meta.env.VITE_API_BASE_URL || 'https://podrafter.fly.dev'
     try {
-      const res = await fetch('https://podrafter.fly.dev/api/chat', {
+      const res = await fetch(`${baseUrl}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- load API base URL from `VITE_API_BASE_URL`
- provide `.env.example` documenting the variable

## Testing
- `npm test -- --watchAll=false` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888f88a0fe88332af23e41ff1782e22