### PR TITLE
Fix Dockerfile.test backend entry

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,8 +12,10 @@ WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the rest of the code
-COPY . /app
+# Copy backend and related resources
+COPY ./backend /app/backend
+COPY ./forms /app/forms
+COPY ./schema /app/schema
 
 # Launch the app with Uvicorn on port 8080
-CMD ["uvicorn", "main:app", "--host=0.0.0.0", "--port=8080"]
+CMD ["uvicorn", "backend.main:app", "--host=0.0.0.0", "--port=8080"]


### PR DESCRIPTION
## Summary
- ensure the Dockerfile used for testing includes backend code
- run the FastAPI app via `backend.main`

## Testing
- `docker build -f Dockerfile.test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b79496634833281b64ec8a8d3aeff