### PR TITLE
Add EOF newlines to config files

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     command: 'npm run dev',
     port: 5173,
     timeout: 120 * 1000,
-    reuseExistingServer: true
+    reuseExistingServer: true,
   },
-  testDir: 'tests'
+  testDir: 'tests',
 })

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -3,4 +3,4 @@ module.exports = {
     tailwindcss: {},
     autoprefixer: {},
   },
-};
+}

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,13 +1,13 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-auto'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
     adapter: adapter(),
     alias: {
-      $src: 'src'
-    }
-  }
-};
+      $src: 'src',
+    },
+  },
+}
 
-export default config;
+export default config

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -5,4 +5,4 @@ module.exports = {
     extend: {},
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
## Summary
- add trailing newlines to various Svelte config files
- run Prettier for consistent formatting

## Testing
- `npx prettier -w postcss.config.cjs tailwind.config.cjs svelte.config.js playwright.config.ts`
- `npm test -- --watchAll=false` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b794e34288332a8115991fae93e45