### PR TITLE
Add Message model for chat endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import openai
 from pydantic import BaseModel
+from typing import Literal
 
 import io
 import json
@@ -94,8 +95,14 @@ async def generate_pdf(data: dict) -> StreamingResponse:
 
 
 # ✅ Add your OpenAI chat endpoint below
+
+class Message(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+
 class ChatRequest(BaseModel):
-    messages: list
+    messages: list[Message]
 
 @app.post("/api/chat")
 async def chat(request: ChatRequest):

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -27,9 +27,7 @@ def test_chat_endpoint(monkeypatch):
         fake_acreate,
     )
 
-    resp = client.post(
-        "/api/chat",
-        json={"messages": [{"role": "user", "content": "hello"}]},
-    )
+    messages = [{"role": "user", "content": "hello"}]
+    resp = client.post("/api/chat", json={"messages": messages})
     assert resp.status_code == 200
     assert resp.json() == {"role": "assistant", "content": "hi"}


### PR DESCRIPTION
## Summary
- define a `Message` model and use it in `ChatRequest`
- adjust chat test to send message objects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_688b7950d0f88332b18d3da1c5859592