### PR TITLE
Fix Dockerfile requirements copy path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install dependencies using root requirements file
-COPY ../requirements.txt /app/requirements.txt
+COPY /requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the code


### PR DESCRIPTION
## Summary
- update backend Dockerfile to copy requirements from repo root

## Testing
- `docker build -f backend/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688bfa3eb7788332bca639d7e45f99d0