### PR TITLE
Remove unused code from Svelte page

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
 
   interface Message {
     role: 'user' | 'bot';
@@ -16,7 +15,6 @@
     messages = [...messages, { role: 'user', content: input }];
 
     // 2️⃣ Capture and clear input
-    const userMessage = input;
     input = '';
 
     // 3️⃣ Call your backend


### PR DESCRIPTION
## Summary
- clean up `+page.svelte` by removing the unused `onMount` import and the `userMessage` variable
- run Prettier on `frontend/src`

## Testing
- `npm test -- --watchAll=false` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_688bfa40e92c83328b2d0857c68e47db