### PR TITLE
feat: render filing templates with Jinja2

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,4 +1,6 @@
 import os
+import io
+import zipfile
 import httpx
 import asyncio
 
@@ -74,6 +76,18 @@ def test_pdf_generation(monkeypatch):
             "PetitionerEmail": "jane@example.com",
             "RespondentName": "John Doe",
         }
+
+        zf = zipfile.ZipFile(io.BytesIO(resp.content))
+        names = zf.namelist()
+        assert "petition.pdf" in names
+        assert "cover_letter.html" in names
+        assert "filing_guide.html" in names
+        cover = zf.read("cover_letter.html").decode()
+        guide = zf.read("filing_guide.html").decode()
+        assert "Jane Doe" in cover
+        assert "Harris County District Clerk’s Office" in cover
+        assert "Harris County District Clerk’s Office" in guide
+        assert "1 Main St" in guide
 
     asyncio.run(_run())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn==0.29.0
 openai>=1.0.0
 jsonschema==4.21.1
 PyPDF2==3.0.1
+jinja2>=3.1.0


### PR DESCRIPTION
## Summary
- add jinja2 dependency
- render cover letter and filing guide into ZIP
- test for generated HTML files

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_b_68aa145682c083329f8ea18aa038b12b