### PR TITLE
fix: use 8080 for local API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@ ALLOWED_ORIGINS=http://localhost:5173
 
 # Example environment variables for local development
 # Base URL for the backend API used by the SvelteKit frontend
-# e.g. http://localhost:8000 or https://your-deploy.com
-VITE_API_BASE_URL=http://localhost:8000
+# e.g. http://localhost:8080 or https://your-deploy.com
+VITE_API_BASE_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pytest
 # start the server (requires OPENAI_API_KEY)
-uvicorn backend.main:app --reload
+uvicorn backend.main:app --reload --port 8080
 # frontend
 cd frontend && npm install
 npm test -- --watchAll=false
@@ -55,6 +55,7 @@ Copy `.env.example` to `.env` and set these keys:
 |------|---------|---------|
 | `OPENAI_API_KEY` | OpenAI token for GPT requests | – |
 | `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins | `http://localhost:5173` |
+| `VITE_API_BASE_URL` | Base URL for the backend API | `http://localhost:8080` |
 
 ### Installing Test Dependencies
 


### PR DESCRIPTION
## Summary
- default VITE_API_BASE_URL to http://localhost:8080
- document new backend port in README

## Testing
- `npm test -- --watchAll=false` *(fails: unknown option)*
- `npm test` *(fails: missing Playwright browser)*
- `npx playwright install` *(fails: 403 downloading Chromium)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1515531483329dcbd33b04d78ff2