### PR TITLE
fix: adjust backend Dockerfile paths and expose port

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,9 +7,10 @@ ENV PYTHONUNBUFFERED=1
 
 # Set working directory
 WORKDIR /app
+EXPOSE 8080
 
 # Install dependencies using root requirements file
-COPY /requirements.txt /app/requirements.txt
+COPY ../requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the code


### PR DESCRIPTION
## Summary
- copy requirements from repository root
- expose port 8080 in backend image
- keep final copy scoped to backend directory

## Testing
- `PYTHONPATH=.. pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aa15e0e05c8332bf1921ebc9d0fbc8