### PR TITLE
feat: add vite configuration

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,30 @@
+// Vite configuration for the SvelteKit frontend
+// - sets dev server port and API proxy
+// - documents build and alias settings
+
+import { sveltekit } from '@sveltejs/kit/vite'
+
+/** @type {import('vite').UserConfig} */
+const config = {
+  plugins: [sveltekit()],
+  server: {
+    port: 5173,
+    proxy: {
+      // proxy API requests to the backend server
+      '/api': 'http://localhost:3000',
+    },
+  },
+  resolve: {
+    alias: {
+      // allow importing from the project root with $src/
+      $src: '/src',
+    },
+  },
+  build: {
+    // generate sourcemaps to aid in debugging
+    sourcemap: true,
+  },
+}
+
+export default config
+


### PR DESCRIPTION
## Summary
- configure Vite for the SvelteKit frontend with dev server options, proxying /api to backend
- document alias and build settings (sourcemaps, $src alias)

## Testing
- `npx playwright test --watchAll=false` *(fails: unknown option)*
- `npm test` *(fails: missing Playwright browsers)*
- `npx playwright install` *(fails: download failed, code 403)*

------
https://chatgpt.com/codex/tasks/task_b_68aa16a53b2083329b3af99d6d54e687