### PR TITLE
build: add jinja2 and fpdf2 dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 pydantic==2.6.4
 fastapi==0.110.0
 uvicorn==0.29.0
-openai>=1.0.0
+openai>=1.0.0,<2.0.0
 jsonschema==4.21.1
 PyPDF2==3.0.1
+jinja2==3.1.3
+fpdf2==2.7.8


### PR DESCRIPTION
## Summary
- add jinja2 and fpdf2 dependencies
- bound openai library to >=1.0.0,<2.0.0

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement jinja2==3.1.3)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_b_68aa177155208332888989891546daa5