### PR TITLE
fix: update Vite proxy to backend port

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,8 @@
 
 import { sveltekit } from '@sveltejs/kit/vite'
 
+const backendPort = process.env.BACKEND_PORT ?? 8080
+
 /** @type {import('vite').UserConfig} */
 const config = {
   plugins: [sveltekit()],
@@ -11,7 +13,7 @@ const config = {
     port: 5173,
     proxy: {
       // proxy API requests to the backend server
-      '/api': 'http://localhost:3000',
+      '/api': `http://localhost:${backendPort}`,
     },
   },
   resolve: {
@@ -27,4 +29,3 @@ const config = {
 }
 
 export default config
-


### PR DESCRIPTION
## Summary
- configure Vite proxy to use backend port from `BACKEND_PORT` env var or default to 8080

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install chromium` *(fails: Download failed - server returned 403)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1d91e2ac8332a94543ea84ab48b1