### PR TITLE
build: add Vite dev dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^10.4.0",
     "prettier": "^3.2.5",
     "eslint": "^8.57.0",
-    "@playwright/test": "^1.42.1"
+    "@playwright/test": "^1.42.1",
+    "vite": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Vite as a dev dependency to the frontend package

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `npm test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1e672510833285b94fe34cbcee65