### PR TITLE
fix: use relative API base path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,6 @@ OPENAI_API_KEY=
 ALLOWED_ORIGINS=http://localhost:5173
 
 # Example environment variables for local development
-# Base URL for the backend API used by the SvelteKit frontend
-# e.g. http://localhost:8080 or https://your-deploy.com
-VITE_API_BASE_URL=http://localhost:8080
+# Base path for the backend API used by the SvelteKit frontend
+# e.g. /api or https://your-deploy.com/api
+VITE_API_BASE_URL=http://localhost:8080/api

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Copy `.env.example` to `.env` and set these keys:
 |------|---------|---------|
 | `OPENAI_API_KEY` | OpenAI token for GPT requests | – |
 | `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins | `http://localhost:5173` |
-| `VITE_API_BASE_URL` | Base URL for the backend API | `http://localhost:8080` |
+| `VITE_API_BASE_URL` | Base path for the backend API | `/api` |
 
 ### Installing Test Dependencies
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -18,9 +18,9 @@
     input = '';
 
     // 3️⃣ Call your backend
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || 'https://podrafter.fly.dev'
+    const baseUrl = import.meta.env.VITE_API_BASE_URL || '/api'
     try {
-      const res = await fetch(`${baseUrl}/api/chat`, {
+      const res = await fetch(`${baseUrl}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- default frontend API calls to a relative `/api` path
- document `VITE_API_BASE_URL` configuration

## Testing
- `npm test -- --watchAll=false` (fails: unknown option)
- `npm test` (fails: browserType.launch: Executable doesn't exist)
- `npx playwright install chromium` (fails: server returned code 403)


------
https://chatgpt.com/codex/tasks/task_b_68aa1f87838083329a176b1d38556a57