### PR TITLE
feat: persist rate limit data in redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Environment configuration for PO Drafter
 OPENAI_API_KEY=
 ALLOWED_ORIGINS=http://localhost:5173
+REDIS_URL=redis://localhost:6379/0
 
 # Example environment variables for local development
 # Base path for the backend API used by the SvelteKit frontend

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ cd PODrafter
 # backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+docker run -d -p 6379:6379 redis:7
 pytest
 # start the server (requires OPENAI_API_KEY)
-uvicorn backend.main:app --reload --port 8080
+REDIS_URL=redis://localhost:6379 uvicorn backend.main:app --reload --port 8080
 # frontend
 cd frontend && npm install
 npm test -- --watchAll=false
@@ -56,6 +57,7 @@ Copy `.env.example` to `.env` and set these keys:
 | `OPENAI_API_KEY` | OpenAI token for GPT requests | – |
 | `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins | `http://localhost:5173` |
 | `VITE_API_BASE_URL` | Base path for the backend API | `/api` |
+| `REDIS_URL` | Redis connection string for rate limiting | `redis://localhost:6379/0` |
 
 ### Installing Test Dependencies
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -7,12 +7,19 @@ from openai.resources.chat.completions import AsyncCompletions
 from PyPDF2 import PdfReader
 import sys
 from pathlib import Path
+import pytest
+import fakeredis.aioredis as fakeredis
 
 os.environ["OPENAI_API_KEY"] = "test"
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from backend.main import MAX_REQUEST_SIZE, app
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+  monkeypatch.setattr("backend.main.redis_client", fakeredis.FakeRedis())
 
 
 def test_health():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ jsonschema==4.21.1
 PyPDF2==3.0.1
 jinja2==3.1.3
 fpdf2==2.7.8
+redis==5.0.1
+fakeredis==2.21.0


### PR DESCRIPTION
## Summary
- use Redis sorted sets for IP rate limiting
- configure REDIS_URL and add setup instructions
- mock Redis in tests with fakeredis

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_b_68aa2b296424833288f32941c6b6a7d0