### PR TITLE
feat: add fillable Texas county PDF templates

### DIFF
--- a/forms/standard/dallas.pdf
+++ b/forms/standard/dallas.pdf
@@ -1,0 +1,189 @@
+%PDF-1.3
+%
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/AcroForm <<
+/Fields [ <<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> ]
+>>
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 612 792 ]
+/Parent 1 0 R
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ]
+>>
+endobj
+5 0 obj
+<<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+6 0 obj
+<<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+7 0 obj
+<<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+8 0 obj
+<<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+9 0 obj
+<<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+10 0 obj
+<<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+11 0 obj
+<<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000917 00000 n 
+0000001063 00000 n 
+0000001178 00000 n 
+0000001294 00000 n 
+0000001413 00000 n 
+0000001535 00000 n 
+0000001655 00000 n 
+0000001776 00000 n 
+trailer
+<<
+/Size 12
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+1896
+%%EOF

--- a/forms/standard/harris.pdf
+++ b/forms/standard/harris.pdf
@@ -1,0 +1,189 @@
+%PDF-1.3
+%
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/AcroForm <<
+/Fields [ <<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> ]
+>>
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 612 792 ]
+/Parent 1 0 R
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ]
+>>
+endobj
+5 0 obj
+<<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+6 0 obj
+<<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+7 0 obj
+<<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+8 0 obj
+<<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+9 0 obj
+<<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+10 0 obj
+<<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+11 0 obj
+<<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000917 00000 n 
+0000001063 00000 n 
+0000001178 00000 n 
+0000001294 00000 n 
+0000001413 00000 n 
+0000001535 00000 n 
+0000001655 00000 n 
+0000001776 00000 n 
+trailer
+<<
+/Size 12
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+1896
+%%EOF

--- a/forms/standard/travis.pdf
+++ b/forms/standard/travis.pdf
@@ -1,0 +1,189 @@
+%PDF-1.3
+%
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/AcroForm <<
+/Fields [ <<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> ]
+>>
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 612 792 ]
+/Parent 1 0 R
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ]
+>>
+endobj
+5 0 obj
+<<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+6 0 obj
+<<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+7 0 obj
+<<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+8 0 obj
+<<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+9 0 obj
+<<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+10 0 obj
+<<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+11 0 obj
+<<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000917 00000 n 
+0000001063 00000 n 
+0000001178 00000 n 
+0000001294 00000 n 
+0000001413 00000 n 
+0000001535 00000 n 
+0000001655 00000 n 
+0000001776 00000 n 
+trailer
+<<
+/Size 12
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+1896
+%%EOF

--- a/forms/standard/tx_general.pdf
+++ b/forms/standard/tx_general.pdf
@@ -1,0 +1,189 @@
+%PDF-1.3
+%
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/AcroForm <<
+/Fields [ <<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> <<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>> ]
+>>
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0 0 612 792 ]
+/Parent 1 0 R
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ]
+>>
+endobj
+5 0 obj
+<<
+/T (CaseNumber)
+/FT /Tx
+/Rect [ 50 750 300 770 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+6 0 obj
+<<
+/T (HearingDate)
+/FT /Tx
+/Rect [ 50 710 300 730 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+7 0 obj
+<<
+/T (PetitionerName)
+/FT /Tx
+/Rect [ 50 670 300 690 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+8 0 obj
+<<
+/T (PetitionerAddress)
+/FT /Tx
+/Rect [ 50 630 300 650 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+9 0 obj
+<<
+/T (PetitionerPhone)
+/FT /Tx
+/Rect [ 50 590 300 610 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+10 0 obj
+<<
+/T (PetitionerEmail)
+/FT /Tx
+/Rect [ 50 550 300 570 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+11 0 obj
+<<
+/T (RespondentName)
+/FT /Tx
+/Rect [ 50 510 300 530 ]
+/Ff 0
+/Type /Annot
+/Subtype /Widget
+/P 4 0 R
+>>
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000917 00000 n 
+0000001063 00000 n 
+0000001178 00000 n 
+0000001294 00000 n 
+0000001413 00000 n 
+0000001535 00000 n 
+0000001655 00000 n 
+0000001776 00000 n 
+trailer
+<<
+/Size 12
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+1896
+%%EOF


### PR DESCRIPTION
## Summary
- add fillable PDF templates for Dallas, Harris, Travis, and statewide petitions
- stub redis dependency in tests for offline execution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aa2f207fb483328fe1d9bf6feb8353