### PR TITLE
fix: copy requirements from build context

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 EXPOSE 8080
 
 # Install dependencies using root requirements file
-COPY ../requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the code


### PR DESCRIPTION
## Summary
- ensure backend Dockerfile copies requirements from project root

## Testing
- `pytest`
- `docker build -f backend/Dockerfile -t podrafter-backend-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa31d5bd2083328d4f826c9f662838