### PR TITLE
fix: sanitize CORS origin list

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -82,7 +82,11 @@ with open(SCHEMA_PATH) as f:
     PETITION_SCHEMA = json.load(f)
 
 # CORS config
-allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+allowed_origins = [
+  o.strip()
+  for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+  if o.strip()
+]
 
 # FastAPI app
 app = FastAPI()


### PR DESCRIPTION
## Summary
- split and strip configured CORS origins, excluding empties

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa3469f95c8332a0519bdbdb60b01a