### PR TITLE
fix: sanitize base URL in chat fetch

### DIFF
--- a/frontend/src/lib/sanitizeBaseUrl.ts
+++ b/frontend/src/lib/sanitizeBaseUrl.ts
@@ -1,0 +1,3 @@
+export function sanitizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '')
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { sanitizeBaseUrl } from '$lib/sanitizeBaseUrl'
 
   interface Message {
     role: 'user' | 'assistant'
@@ -18,9 +19,10 @@
     input = ''
 
     // 3️⃣ Call your backend
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || '/api'
+    const baseUrl = sanitizeBaseUrl(import.meta.env.VITE_API_BASE_URL || '/api')
+    const url = `${baseUrl}/chat`
     try {
-      const res = await fetch(`${baseUrl}/chat`, {
+      const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ messages })

--- a/frontend/tests/baseUrl.spec.ts
+++ b/frontend/tests/baseUrl.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+import { sanitizeBaseUrl } from '../src/lib/sanitizeBaseUrl'
+
+test('baseUrl values with or without trailing slash match', () => {
+  const noSlash = sanitizeBaseUrl('https://api.example.com')
+  const withSlash = sanitizeBaseUrl('https://api.example.com/')
+  expect(withSlash).toBe(noSlash)
+})


### PR DESCRIPTION
## Summary
- sanitize base URL and build chat endpoint with `${baseUrl}/chat`
- add `sanitizeBaseUrl` utility
- test base URL handling with and without trailing slash

## Testing
- `npx prettier -w src/routes/+page.svelte src/lib/sanitizeBaseUrl.ts tests/baseUrl.spec.ts` *(fails: No parser could be inferred for file "/workspace/PODrafter/frontend/src/routes/+page.svelte")*
- `npm test -- --watchAll=false` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa383346a08332a894acddde9e5440