### PR TITLE
test: use Playwright base URL

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
     reuseExistingServer: true,
   },
   testDir: 'tests',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
 })

--- a/frontend/tests/example.spec.ts
+++ b/frontend/tests/example.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
 test('home page has title', async ({ page }) => {
-  await page.goto('http://localhost:5173/')
+  await page.goto('/')
   await expect(page.locator('h1')).toHaveText('PO Drafter Chat Wizard')
 })


### PR DESCRIPTION
## Summary
- configure Playwright with baseURL for dev server
- load home page via relative path in example test

## Testing
- `npm test -- --watchAll=false` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa4144e1d883329b7b5ccbf64fa414