### PR TITLE
fix: build backend image from repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ npm test -- --watchAll=false
 npm run dev
 ```
 
+### Docker build
+
+Build the backend image from the repository root:
+
+```bash
+docker build -f backend/Dockerfile .
+```
+
 ### Environment Variables
 
 Copy `.env.example` to `.env` and set these keys:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,8 +13,8 @@ EXPOSE 8080
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the rest of the code
-COPY . /app
+# Copy the backend code
+COPY backend/ /app
 
 # Launch the app with Uvicorn on port 8080
 CMD ["uvicorn", "main:app", "--host=0.0.0.0", "--port=8080"]


### PR DESCRIPTION
## Summary
- copy backend source when building image from repo root
- document new docker build command

## Testing
- `pytest`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test -- --watchAll=false` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa41ede3d08332bb6939f7e9d53734