### PR TITLE
Add template checksum verification

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -60,6 +60,7 @@ ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 SENSITIVE_PATHS = {"/api/chat", "/pdf"}
 DISALLOWED_PATTERNS = [re.compile(p, re.IGNORECASE) for p in ["<script", "javascript:", "data:"]]
 
+# SHA256 checksums for standard form templates
 TEMPLATE_CHECKSUMS = {
   "dallas.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",
   "harris.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",

--- a/backend/tests/test_template_checksums.py
+++ b/backend/tests/test_template_checksums.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+from pathlib import Path
+import hashlib
+
+# stub redis module for import side effects
+redis_stub = types.ModuleType("redis")
+redis_asyncio_stub = types.ModuleType("redis.asyncio")
+
+def from_url(*args, **kwargs):
+  return None
+
+redis_asyncio_stub.from_url = from_url
+redis_stub.asyncio = redis_asyncio_stub
+sys.modules["redis"] = redis_stub
+sys.modules["redis.asyncio"] = redis_asyncio_stub
+
+os.environ["OPENAI_API_KEY"] = "test"
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.main import TEMPLATE_CHECKSUMS, FORMS_DIR
+
+
+def test_template_checksums():
+  for path in FORMS_DIR.glob("*.pdf"):
+    with open(path, "rb") as f:
+      actual = hashlib.sha256(f.read()).hexdigest()
+    expected = TEMPLATE_CHECKSUMS.get(path.name)
+    assert expected == actual, f"{path.name} checksum mismatch"


### PR DESCRIPTION
## Summary
- document SHA256 checksums for standard form templates
- add test ensuring template checksums match

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa52a390c88332acea445f92990c8b