### PR TITLE
feat: enforce strict CORS origin validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Environment configuration for PO Drafter
 OPENAI_API_KEY=
+# Allowed CORS origins (comma-separated URLs, wildcards * are rejected)
 ALLOWED_ORIGINS=http://localhost:5173
 REDIS_URL=redis://localhost:6379/0
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ Copy `.env.example` to `.env` and set these keys:
 | Name | Purpose | Default |
 |------|---------|---------|
 | `OPENAI_API_KEY` | OpenAI token for GPT requests | – |
-| `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins | `http://localhost:5173` |
+| `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins (exact URLs; wildcards `*` forbidden) | `http://localhost:5173` |
 | `VITE_API_BASE_URL` | Base path for the backend API | `/api` |
 | `REDIS_URL` | Redis connection string for rate limiting | `redis://localhost:6379/0` |
+
+Only exact origins are accepted. Separate multiple entries with commas and avoid wildcards (`*`), which are rejected for security.
 
 ### Installing Test Dependencies
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -199,6 +199,22 @@ def test_chat_openai_failure(monkeypatch):
   asyncio.run(_run())
 
 
+def test_invalid_allowed_origin(monkeypatch):
+  from backend import main
+
+  monkeypatch.setenv("ALLOWED_ORIGINS", "not-a-url")
+  with pytest.raises(RuntimeError):
+    main.get_allowed_origins()
+
+
+def test_wildcard_allowed_origin(monkeypatch):
+  from backend import main
+
+  monkeypatch.setenv("ALLOWED_ORIGINS", "http://example.com,*")
+  with pytest.raises(RuntimeError):
+    main.get_allowed_origins()
+
+
 def test_chat_rejects_bad_content():
   async def _run():
     messages = [{"role": "user", "content": "<script>bad()</script>"}]


### PR DESCRIPTION
## Summary
- validate ALLOWED_ORIGINS entries and reject wildcards or malformed URLs
- document secure CORS configuration defaults
- test invalid and wildcard origin configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa53a5134c833290d66c4fc5f68d12