### PR TITLE
feat: require API key for chat endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ OPENAI_API_KEY=
 # Allowed CORS origins (comma-separated URLs, wildcards * are rejected)
 ALLOWED_ORIGINS=http://localhost:5173
 REDIS_URL=redis://localhost:6379/0
+CHAT_API_KEY=
 
 # Example environment variables for local development
 # Base path for the backend API used by the SvelteKit frontend

--- a/README.md
+++ b/README.md
@@ -66,8 +66,13 @@ Copy `.env.example` to `.env` and set these keys:
 | `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins (exact URLs; wildcards `*` forbidden) | `http://localhost:5173` |
 | `VITE_API_BASE_URL` | Base path for the backend API | `/api` |
 | `REDIS_URL` | Redis connection string for rate limiting | `redis://localhost:6379/0` |
+| `CHAT_API_KEY` | shared secret for `/api/chat`; sent via `X-API-Key` header | – |
 
 Only exact origins are accepted. Separate multiple entries with commas and avoid wildcards (`*`), which are rejected for security.
+
+### Chat authentication
+
+Requests to `/api/chat` must include an `X-API-Key` header matching `CHAT_API_KEY`. Ensure the frontend adds this header to chat requests.
 
 ### Installing Test Dependencies
 


### PR DESCRIPTION
## Summary
- secure `/api/chat` with `X-API-Key` check
- document `CHAT_API_KEY` usage for frontend integration
- test missing key rejection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aa5b2403108332919d0af27c07b8b1