### PR TITLE
feat: honor proxy headers for rate limiting

### DIFF
--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -95,3 +95,31 @@ def test_store_size_pruning(monkeypatch):
     assert '1.1.1.1' not in main.fallback_store
 
   asyncio.run(_run())
+
+
+def test_rate_limit_with_x_forwarded_for(monkeypatch):
+  async def _run():
+    monkeypatch.setattr(main, 'RATE_LIMIT', 1)
+    headers = {'x-forwarded-for': '5.5.5.5'}
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app, client=('1.1.1.1', 0)), base_url='http://testserver') as client:
+      resp1 = await client.get('/health', headers=headers)
+    assert resp1.status_code == 200
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app, client=('2.2.2.2', 0)), base_url='http://testserver') as client:
+      resp2 = await client.get('/health', headers=headers)
+    assert resp2.status_code == 429
+
+  asyncio.run(_run())
+
+
+def test_rate_limit_uses_first_forwarded_ip(monkeypatch):
+  async def _run():
+    monkeypatch.setattr(main, 'RATE_LIMIT', 1)
+    headers1 = {'x-forwarded-for': '1.1.1.1, 2.2.2.2'}
+    headers2 = {'x-forwarded-for': '1.1.1.1, 3.3.3.3'}
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=main.app, client=('5.5.5.5', 0)), base_url='http://testserver') as client:
+      resp1 = await client.get('/health', headers=headers1)
+      resp2 = await client.get('/health', headers=headers2)
+    assert resp1.status_code == 200
+    assert resp2.status_code == 429
+
+  asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add ProxyHeadersMiddleware to parse X-Forwarded-For
- rate limiter reads canonical client IP
- test rate limiting behavior with proxy headers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa5c3ce680833287e83c5c688243ec