### PR TITLE
fix: sanitize county clerk address rendering

### DIFF
--- a/backend/templates/cover_letter.html
+++ b/backend/templates/cover_letter.html
@@ -67,7 +67,7 @@
   </div>
 
   <div class="clerk-info">
-    <p>{{ county_clerk_address | replace('\n', '<br>') | safe }}</p>
+    <p>{{ county_clerk_address | e | replace('\n', '<br>' | safe) | safe }}</p>
   </div>
 
   <p>Re: <strong>{{ petitioner_full_name }}</strong> v. <strong>{{ respondent_full_name }}</strong></p>

--- a/backend/templates/filing_guide.html
+++ b/backend/templates/filing_guide.html
@@ -80,7 +80,7 @@
       <li>Review the checklist below to ensure completion.</li>
       <li>Place documents in the provided manila envelope.</li>
       <li>Submit to the Clerk’s office at:</li>
-      <p>{{ county_clerk_address | replace('\n', '<br>') | safe }}</p>
+      <p>{{ county_clerk_address | e | replace('\n', '<br>' | safe) | safe }}</p>
       <li>Request fee waiver and ask for file-stamping.</li>
       <li>Obtain file-stamped copy and retain for your records.</li>
       <li>Mail the stamped copy back to:</li>

--- a/backend/tests/test_template_sanitization.py
+++ b/backend/tests/test_template_sanitization.py
@@ -1,0 +1,35 @@
+import pytest
+from datetime import datetime
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "templates"
+env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)), autoescape=True)
+env.filters["date"] = lambda value, fmt: value.strftime(fmt)
+
+
+@pytest.mark.parametrize(
+  "template,context",
+  [
+    (
+      "cover_letter.html",
+      {
+        "county": "Test",
+        "today": datetime(2024, 1, 1),
+        "petitioner_full_name": "Jane",
+        "respondent_full_name": "John",
+      },
+    ),
+    (
+      "filing_guide.html",
+      {"county": "Test", "petitioner_address": "123 Main"},
+    ),
+  ],
+)
+def test_county_clerk_address_escaped(template, context):
+  malicious = "<script>alert(1)</script>\n123 Main"
+  context["county_clerk_address"] = malicious
+  rendered = env.get_template(template).render(**context)
+  assert "<script>" not in rendered
+  assert "&lt;script&gt;alert(1)&lt;/script&gt;<br>123 Main" in rendered
+


### PR DESCRIPTION
## Summary
- escape county clerk address in HTML templates to prevent injection
- add unit test to ensure malicious HTML is escaped

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa5d53b6788332838f21717b41fc4a