### PR TITLE
fix: validate base URL protocol

### DIFF
--- a/frontend/src/lib/sanitizeBaseUrl.ts
+++ b/frontend/src/lib/sanitizeBaseUrl.ts
@@ -1,3 +1,7 @@
 export function sanitizeBaseUrl(url: string): string {
+  const protocol = new URL(url).protocol
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new Error(`unsupported protocol: ${protocol}`)
+  }
   return url.replace(/\/+$/, '')
 }

--- a/frontend/tests/baseUrl.spec.ts
+++ b/frontend/tests/baseUrl.spec.ts
@@ -6,3 +6,12 @@ test('baseUrl values with or without trailing slash match', () => {
   const withSlash = sanitizeBaseUrl('https://api.example.com/')
   expect(withSlash).toBe(noSlash)
 })
+
+test('allows http and https protocols', () => {
+  expect(sanitizeBaseUrl('http://api.example.com/')).toBe('http://api.example.com')
+  expect(sanitizeBaseUrl('https://api.example.com/')).toBe('https://api.example.com')
+})
+
+test('throws on unsupported protocol', () => {
+  expect(() => sanitizeBaseUrl('ftp://api.example.com')).toThrow()
+})


### PR DESCRIPTION
## Summary
- validate base URL scheme to allow only http and https
- add unit tests for valid and unsupported protocols

## Testing
- `npm test -- --watchAll=false` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_b_68aa64bd74808332a9b305f580094326