### PR TITLE
feat: include chat API key header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ OPENAI_API_KEY=
 ALLOWED_ORIGINS=http://localhost:5173
 REDIS_URL=redis://localhost:6379/0
 CHAT_API_KEY=
+VITE_CHAT_API_KEY=
 
 # Example environment variables for local development
 # Base path for the backend API used by the SvelteKit frontend

--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@ Copy `.env.example` to `.env` and set these keys:
 | `VITE_API_BASE_URL` | Base path for the backend API | `/api` |
 | `REDIS_URL` | Redis connection string for rate limiting | `redis://localhost:6379/0` |
 | `CHAT_API_KEY` | shared secret for `/api/chat`; sent via `X-API-Key` header | – |
+| `VITE_CHAT_API_KEY` | frontend copy of `CHAT_API_KEY` for requests | – |
 
 Only exact origins are accepted. Separate multiple entries with commas and avoid wildcards (`*`), which are rejected for security.
 
 ### Chat authentication
 
-Requests to `/api/chat` must include an `X-API-Key` header matching `CHAT_API_KEY`. Ensure the frontend adds this header to chat requests.
+Requests to `/api/chat` must include an `X-API-Key` header matching `CHAT_API_KEY`. The frontend reads this value from `VITE_CHAT_API_KEY` at build time and attaches it to requests.
+
+For local development, set both `CHAT_API_KEY` and `VITE_CHAT_API_KEY` in `.env` to the same value. In production, configure the backend's `CHAT_API_KEY` and provide `VITE_CHAT_API_KEY` during the frontend build so the browser sends the correct header.
 
 ### Request size limits
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -22,9 +22,13 @@
     const baseUrl = sanitizeBaseUrl(import.meta.env.VITE_API_BASE_URL || '/api')
     const url = `${baseUrl}/chat`
     try {
+      const apiKey = import.meta.env.VITE_CHAT_API_KEY
       const res = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(apiKey ? { 'X-API-Key': apiKey } : {})
+        },
         body: JSON.stringify({ messages })
       })
 


### PR DESCRIPTION
## Summary
- send chat requests with `X-API-Key` from `VITE_CHAT_API_KEY`
- document `VITE_CHAT_API_KEY` for local and production builds

## Testing
- `npm test -- --watchAll=false` *(fails: playwright: not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ab42d3e0908332a6b82f35bc21f46e