### PR TITLE
chore: update SvelteKit to Vite 5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,9 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^1.0.0",
-    "@sveltejs/adapter-auto": "^1.0.0",
+    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/adapter-vercel": "^5.0.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.0.0",
     "typescript": "^5.0.0",
     "tailwindcss": "^3.3.0",

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto'
+import adapter from '@sveltejs/adapter-vercel'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
## Summary
- upgrade `@sveltejs/kit` to v2 with Vite 5 compatibility
- switch to `@sveltejs/adapter-vercel` and add Vite Svelte plugin

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm run build` *(fails: vite: not found)*
- `npm run preview` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab576629d48332b87ac9d9ce1599dd