### PR TITLE
chore: update sveltekit for vite5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^1.0.0",
+    "@sveltejs/kit": "^2.0.0",
     "@sveltejs/adapter-vercel": "^5.0.0",
     "svelte": "^4.0.0",
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- upgrade `@sveltejs/kit` to version compatible with Vite 5

## Testing
- `npm test -- --watchAll=false` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab62d2edc483328a5cd3098792cf76