### PR TITLE
chore: upgrade frontend to Svelte 5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ OPENAI_API_KEY=
 ALLOWED_ORIGINS=http://localhost:5173
 REDIS_URL=redis://localhost:6379/0
 CHAT_API_KEY=
-VITE_CHAT_API_KEY=
+PUBLIC_CHAT_API_KEY=
 
 # Example environment variables for local development
 # Base path for the backend API used by the SvelteKit frontend
 # e.g. /api or https://your-deploy.com/api
-VITE_API_BASE_URL=http://localhost:8080/api
+PUBLIC_API_BASE_URL=http://localhost:8080/api

--- a/README.md
+++ b/README.md
@@ -64,18 +64,18 @@ Copy `.env.example` to `.env` and set these keys:
 |------|---------|---------|
 | `OPENAI_API_KEY` | OpenAI token for GPT requests | – |
 | `ALLOWED_ORIGINS` | comma‑separated list of allowed CORS origins (exact URLs; wildcards `*` forbidden) | `http://localhost:5173` |
-| `VITE_API_BASE_URL` | Base path for the backend API | `/api` |
+| `PUBLIC_API_BASE_URL` | Base path for the backend API | `/api` |
 | `REDIS_URL` | Redis connection string for rate limiting | `redis://localhost:6379/0` |
 | `CHAT_API_KEY` | shared secret for `/api/chat`; sent via `X-API-Key` header | – |
-| `VITE_CHAT_API_KEY` | frontend copy of `CHAT_API_KEY` for requests | – |
+| `PUBLIC_CHAT_API_KEY` | frontend copy of `CHAT_API_KEY` for requests | – |
 
 Only exact origins are accepted. Separate multiple entries with commas and avoid wildcards (`*`), which are rejected for security.
 
 ### Chat authentication
 
-Requests to `/api/chat` must include an `X-API-Key` header matching `CHAT_API_KEY`. The frontend reads this value from `VITE_CHAT_API_KEY` at build time and attaches it to requests.
+Requests to `/api/chat` must include an `X-API-Key` header matching `CHAT_API_KEY`. The frontend reads this value from `PUBLIC_CHAT_API_KEY` at build time and attaches it to requests.
 
-For local development, set both `CHAT_API_KEY` and `VITE_CHAT_API_KEY` in `.env` to the same value. In production, configure the backend's `CHAT_API_KEY` and provide `VITE_CHAT_API_KEY` during the frontend build so the browser sends the correct header.
+For local development, set both `CHAT_API_KEY` and `PUBLIC_CHAT_API_KEY` in `.env` to the same value. In production, configure the backend's `CHAT_API_KEY` and provide `PUBLIC_CHAT_API_KEY` during the frontend build so the browser sends the correct header.
 
 ### Request size limits
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,9 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/adapter-vercel": "^5.0.0",
-    "svelte": "^4.0.0",
+    "@sveltejs/kit": "^2.5.0",
+    "@sveltejs/adapter-vercel": "^5.3.0",
+    "svelte": "^5.0.0",
     "typescript": "^5.0.0",
     "tailwindcss": "^3.3.0",
     "postcss": "^8.4.0",

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,10 +19,10 @@
     input = ''
 
     // 3️⃣ Call your backend
-    const baseUrl = sanitizeBaseUrl(import.meta.env.VITE_API_BASE_URL || '/api')
+    const baseUrl = sanitizeBaseUrl(import.meta.env.PUBLIC_API_BASE_URL || '/api')
     const url = `${baseUrl}/chat`
     try {
-      const apiKey = import.meta.env.VITE_CHAT_API_KEY
+      const apiKey = import.meta.env.PUBLIC_CHAT_API_KEY
       const res = await fetch(url, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- upgrade Svelte and SvelteKit dependencies for Svelte 5 compatibility
- adopt PUBLIC_ environment variables across frontend and docs

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test -- --watchAll=false` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab65264c148332b608db3f64bbc1ee