### PR TITLE
chore: bump vite to ^6.3.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,6 @@
     "prettier": "^3.2.5",
     "eslint": "^8.57.0",
     "@playwright/test": "^1.42.1",
-    "vite": "^5.0.0"
+    "vite": "^6.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump vite dev dependency to ^6.3.0

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test -- --watchAll=false` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab7a08991c83329246db686820d79e