### PR TITLE
fix: align backend Docker paths

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -7,15 +7,20 @@ ENV PYTHONUNBUFFERED=1
 
 # Set working directory
 WORKDIR /app
+EXPOSE 8080
 
 # Install dependencies using unified requirements file
-COPY ./requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend and related resources
-COPY ./backend /app/backend
-COPY ./forms /app/forms
-COPY ./schema /app/schema
+COPY backend /app/backend
+COPY forms /app/forms
+COPY schema /app/schema
+
+# Configure resource paths
+ENV FORMS_DIR=/app/forms/standard
+ENV SCHEMA_PATH=/app/schema/petition.schema.json
 
 # Launch the app with Uvicorn on port 8080
 CMD ["uvicorn", "backend.main:app", "--host=0.0.0.0", "--port=8080"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,8 +13,14 @@ EXPOSE 8080
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the backend code
-COPY backend/ /app
+# Copy backend and required resources
+COPY backend /app/backend
+COPY forms /app/forms
+COPY schema /app/schema
+
+# Configure resource paths
+ENV FORMS_DIR=/app/forms/standard
+ENV SCHEMA_PATH=/app/schema/petition.schema.json
 
 # Launch the app with Uvicorn on port 8080
-CMD ["uvicorn", "main:app", "--host=0.0.0.0", "--port=8080"]
+CMD ["uvicorn", "backend.main:app", "--host=0.0.0.0", "--port=8080"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,8 +33,8 @@ from typing import Literal
 
 # Base paths
 BASE_DIR = Path(__file__).resolve().parent.parent
-SCHEMA_PATH = BASE_DIR / "schema" / "petition.schema.json"
-FORMS_DIR = BASE_DIR / "forms" / "standard"
+SCHEMA_PATH = Path(os.getenv("SCHEMA_PATH", BASE_DIR / "schema" / "petition.schema.json"))
+FORMS_DIR = Path(os.getenv("FORMS_DIR", BASE_DIR / "forms" / "standard"))
 
 # Mapping of petition data keys to PDF form fields
 FIELD_MAP = {


### PR DESCRIPTION
## Summary
- copy `forms` and `schema` directories into backend image
- configure resource paths via env vars
- allow backend to override schema and forms paths via environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab7df1550c8332a6ad73fcdce78ec2