### PR TITLE
fix: clarify chat API key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ OPENAI_API_KEY=
 # Allowed CORS origins (comma-separated URLs, wildcards * are rejected)
 ALLOWED_ORIGINS=http://localhost:5173
 REDIS_URL=redis://localhost:6379/0
+# Shared secret for /api/chat
 CHAT_API_KEY=
+# Frontend copy; must match CHAT_API_KEY for local development
 PUBLIC_CHAT_API_KEY=
 
 # Example environment variables for local development

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Copy `.env.example` to `.env` and set these keys:
 | `PUBLIC_API_BASE_URL` | Base path for the backend API | `/api` |
 | `REDIS_URL` | Redis connection string for rate limiting | `redis://localhost:6379/0` |
 | `CHAT_API_KEY` | shared secret for `/api/chat`; sent via `X-API-Key` header | – |
-| `PUBLIC_CHAT_API_KEY` | frontend copy of `CHAT_API_KEY` for requests | – |
+| `PUBLIC_CHAT_API_KEY` | frontend copy of `CHAT_API_KEY`; must match `CHAT_API_KEY` in development | – |
 
 Only exact origins are accepted. Separate multiple entries with commas and avoid wildcards (`*`), which are rejected for security.
 
@@ -75,7 +75,7 @@ Only exact origins are accepted. Separate multiple entries with commas and avoid
 
 Requests to `/api/chat` must include an `X-API-Key` header matching `CHAT_API_KEY`. The frontend reads this value from `PUBLIC_CHAT_API_KEY` at build time and attaches it to requests.
 
-For local development, set both `CHAT_API_KEY` and `PUBLIC_CHAT_API_KEY` in `.env` to the same value. In production, configure the backend's `CHAT_API_KEY` and provide `PUBLIC_CHAT_API_KEY` during the frontend build so the browser sends the correct header.
+For local development, set both `CHAT_API_KEY` and `PUBLIC_CHAT_API_KEY` in `.env` to the same value; mismatched keys will return **401 Unauthorized**. If `CHAT_API_KEY` is unset, the backend falls back to `PUBLIC_CHAT_API_KEY` to simplify local setup. In production, configure the backend's `CHAT_API_KEY` and provide `PUBLIC_CHAT_API_KEY` during the frontend build so the browser sends the correct header.
 
 ### Request size limits
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -59,7 +59,8 @@ REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 redis_client = redis.from_url(REDIS_URL, decode_responses=True)
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
-CHAT_API_KEY = os.getenv("CHAT_API_KEY")
+# Use PUBLIC_CHAT_API_KEY as fallback for local development
+CHAT_API_KEY = os.getenv("CHAT_API_KEY") or os.getenv("PUBLIC_CHAT_API_KEY")
 SENSITIVE_PATHS = {"/api/chat", "/pdf"}
 DISALLOWED_PATTERNS = [re.compile(p, re.IGNORECASE) for p in ["<script", "javascript:", "data:"]]
 

--- a/backend/tests/test_chat_key_fallback.py
+++ b/backend/tests/test_chat_key_fallback.py
@@ -1,0 +1,75 @@
+import asyncio
+import httpx
+import types
+import importlib
+import sys
+from pathlib import Path
+import pytest
+from openai.resources.chat.completions import AsyncCompletions
+
+# stub redis module for tests
+redis_stub = types.ModuleType("redis")
+redis_asyncio_stub = types.ModuleType("redis.asyncio")
+
+def from_url(*args, **kwargs):
+  return None
+
+redis_asyncio_stub.from_url = from_url
+redis_stub.asyncio = redis_asyncio_stub
+sys.modules["redis"] = redis_stub
+sys.modules["redis.asyncio"] = redis_asyncio_stub
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+class DummyRedis:
+  async def zremrangebyscore(self, *args, **kwargs):
+    pass
+
+  async def zcard(self, *args, **kwargs):
+    return 0
+
+  async def zadd(self, *args, **kwargs):
+    pass
+
+  async def expire(self, *args, **kwargs):
+    pass
+
+
+@pytest.fixture
+def app(monkeypatch):
+  monkeypatch.setenv("OPENAI_API_KEY", "test")
+  monkeypatch.delenv("CHAT_API_KEY", raising=False)
+  monkeypatch.setenv("PUBLIC_CHAT_API_KEY", "test-key")
+  import backend.main as main
+  importlib.reload(main)
+  monkeypatch.setattr("backend.main.redis_client", DummyRedis())
+  return main.app
+
+
+def test_public_key_fallback(monkeypatch, app):
+  async def fake_create(self, *args, **kwargs):
+    class Msg:
+      def model_dump(self):
+        return {"role": "assistant", "content": "hi"}
+
+    class Choice:
+      message = Msg()
+
+    class Resp:
+      choices = [Choice()]
+
+    return Resp()
+
+  async def _run():
+    monkeypatch.setattr(AsyncCompletions, "create", fake_create)
+    async with httpx.AsyncClient(
+      transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+      resp = await client.post(
+        "/api/chat", json={"messages": []}, headers={"X-API-Key": "test-key"}
+      )
+    assert resp.status_code == 200
+
+  asyncio.run(_run())
+


### PR DESCRIPTION
## Summary
- document that CHAT_API_KEY and PUBLIC_CHAT_API_KEY must match for local dev
- fall back to PUBLIC_CHAT_API_KEY when CHAT_API_KEY is unset
- add test covering PUBLIC_CHAT_API_KEY fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab815881bc833284c18a3255b2115c