### PR TITLE
fix: centralize redis stubs and align API base URL defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,4 @@ PUBLIC_CHAT_API_KEY=
 # Example environment variables for local development
 # Base path for the backend API used by the SvelteKit frontend
 # e.g. /api or https://your-deploy.com/api
-PUBLIC_API_BASE_URL=http://localhost:8080/api
+PUBLIC_API_BASE_URL=/api

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,15 @@
+import types
+import sys
+
+redis_stub = types.ModuleType("redis")
+redis_asyncio_stub = types.ModuleType("redis.asyncio")
+
+
+def from_url(*args, **kwargs):
+  return None
+
+
+redis_asyncio_stub.from_url = from_url
+redis_stub.asyncio = redis_asyncio_stub
+sys.modules["redis"] = redis_stub
+sys.modules["redis.asyncio"] = redis_asyncio_stub

--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -3,20 +3,7 @@ import sys
 import asyncio
 import httpx
 from pathlib import Path
-import types
 import pytest
-
-# stub redis module for tests
-redis_stub = types.ModuleType("redis")
-redis_asyncio_stub = types.ModuleType("redis.asyncio")
-
-def from_url(*args, **kwargs):
-  return None
-
-redis_asyncio_stub.from_url = from_url
-redis_stub.asyncio = redis_asyncio_stub
-sys.modules["redis"] = redis_stub
-sys.modules["redis.asyncio"] = redis_asyncio_stub
 
 os.environ["OPENAI_API_KEY"] = "test"
 os.environ["CHAT_API_KEY"] = "test-key"

--- a/backend/tests/test_chat_key_fallback.py
+++ b/backend/tests/test_chat_key_fallback.py
@@ -1,23 +1,10 @@
 import asyncio
 import httpx
-import types
 import importlib
 import sys
 from pathlib import Path
 import pytest
 from openai.resources.chat.completions import AsyncCompletions
-
-# stub redis module for tests
-redis_stub = types.ModuleType("redis")
-redis_asyncio_stub = types.ModuleType("redis.asyncio")
-
-def from_url(*args, **kwargs):
-  return None
-
-redis_asyncio_stub.from_url = from_url
-redis_stub.asyncio = redis_asyncio_stub
-sys.modules["redis"] = redis_stub
-sys.modules["redis.asyncio"] = redis_asyncio_stub
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -8,17 +8,6 @@ from PyPDF2 import PdfReader
 import sys
 from pathlib import Path
 import pytest
-import types
-
-# stub redis module for tests
-redis_stub = types.ModuleType("redis")
-redis_asyncio_stub = types.ModuleType("redis.asyncio")
-def from_url(*args, **kwargs):
-  return None
-redis_asyncio_stub.from_url = from_url
-redis_stub.asyncio = redis_asyncio_stub
-sys.modules["redis"] = redis_stub
-sys.modules["redis.asyncio"] = redis_asyncio_stub
 
 os.environ["OPENAI_API_KEY"] = "test"
 os.environ["CHAT_API_KEY"] = "test-key"

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,13 +1,8 @@
 import os
 import asyncio
 import httpx
-import sys
-import types
 import pytest
-
-# stub redis module with failing client
-redis_stub = types.ModuleType('redis')
-redis_asyncio_stub = types.ModuleType('redis.asyncio')
+import redis.asyncio as redis_asyncio
 
 class DummyRedis:
   async def zremrangebyscore(self, *args, **kwargs):
@@ -28,10 +23,7 @@ class DummyRedis:
 def from_url(*args, **kwargs):
   return DummyRedis()
 
-redis_asyncio_stub.from_url = from_url
-redis_stub.asyncio = redis_asyncio_stub
-sys.modules['redis'] = redis_stub
-sys.modules['redis.asyncio'] = redis_asyncio_stub
+redis_asyncio.from_url = from_url
 
 os.environ['OPENAI_API_KEY'] = 'test'
 

--- a/backend/tests/test_template_checksums.py
+++ b/backend/tests/test_template_checksums.py
@@ -1,20 +1,7 @@
 import os
 import sys
-import types
 from pathlib import Path
 import hashlib
-
-# stub redis module for import side effects
-redis_stub = types.ModuleType("redis")
-redis_asyncio_stub = types.ModuleType("redis.asyncio")
-
-def from_url(*args, **kwargs):
-  return None
-
-redis_asyncio_stub.from_url = from_url
-redis_stub.asyncio = redis_asyncio_stub
-sys.modules["redis"] = redis_stub
-sys.modules["redis.asyncio"] = redis_asyncio_stub
 
 os.environ["OPENAI_API_KEY"] = "test"
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,7 +19,7 @@
     input = ''
 
     // 3️⃣ Call your backend
-    const baseUrl = sanitizeBaseUrl(import.meta.env.PUBLIC_API_BASE_URL || '/api')
+    const baseUrl = sanitizeBaseUrl(import.meta.env.PUBLIC_API_BASE_URL ?? '/api')
     const url = `${baseUrl}/chat`
     try {
       const apiKey = import.meta.env.PUBLIC_CHAT_API_KEY


### PR DESCRIPTION
## Summary
- centralize redis test stubs via shared conftest
- standardize API base URL handling with nullish fallback and `/api` example

## Testing
- `pytest backend/tests`
- `npm test -- --watchAll=false` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab832a82e48332b10c5d08ab2fccd9