### PR TITLE
fix: remove path hacks from backend tests

### DIFF
--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -1,14 +1,10 @@
 import os
-import sys
 import asyncio
 import httpx
-from pathlib import Path
 import pytest
 
 os.environ["OPENAI_API_KEY"] = "test"
 os.environ["CHAT_API_KEY"] = "test-key"
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from backend.main import MAX_REQUEST_SIZE, app
 

--- a/backend/tests/test_chat_key_fallback.py
+++ b/backend/tests/test_chat_key_fallback.py
@@ -1,12 +1,8 @@
 import asyncio
 import httpx
 import importlib
-import sys
-from pathlib import Path
 import pytest
 from openai.resources.chat.completions import AsyncCompletions
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 
 class DummyRedis:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -5,14 +5,10 @@ import asyncio
 import httpx
 from openai.resources.chat.completions import AsyncCompletions
 from PyPDF2 import PdfReader
-import sys
-from pathlib import Path
 import pytest
 
 os.environ["OPENAI_API_KEY"] = "test"
 os.environ["CHAT_API_KEY"] = "test-key"
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from backend.main import MAX_REQUEST_SIZE, app
 

--- a/backend/tests/test_template_checksums.py
+++ b/backend/tests/test_template_checksums.py
@@ -1,11 +1,7 @@
 import os
-import sys
-from pathlib import Path
 import hashlib
 
 os.environ["OPENAI_API_KEY"] = "test"
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from backend.main import TEMPLATE_CHECKSUMS, FORMS_DIR
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- configure pytest to add project root to Python path
- remove manual sys.path tweaks from backend tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab85677268833296ab3cffb1a4e2ef