### PR TITLE
fix: make frontend dev port configurable

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from '@playwright/test'
 
+const frontendPort = Number(process.env.FRONTEND_PORT) || 5173
+
 export default defineConfig({
   webServer: {
     command: 'npm run dev',
-    port: 5173,
+    port: frontendPort,
     timeout: 120 * 1000,
     reuseExistingServer: true,
+    env: { FRONTEND_PORT: String(frontendPort) },
   },
   testDir: 'tests',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: `http://localhost:${frontendPort}`,
   },
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,12 +5,13 @@
 import { sveltekit } from '@sveltejs/kit/vite'
 
 const backendPort = process.env.BACKEND_PORT ?? 8080
+const frontendPort = Number(process.env.FRONTEND_PORT) || 5173
 
 /** @type {import('vite').UserConfig} */
 const config = {
   plugins: [sveltekit()],
   server: {
-    port: 5173,
+    port: frontendPort,
     proxy: {
       // proxy API requests to the backend server
       '/api': `http://localhost:${backendPort}`,


### PR DESCRIPTION
## Summary
- read frontend port from FRONTEND_PORT env var in Vite config
- let Playwright tests use the same env-configured port

## Testing
- `npm test -- --watchAll=false` *(fails: sh: 1: playwright: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_b_68ab863101508332bb78c970cdc09f65