### PR TITLE
fix: handle relative base URLs in sanitizeBaseUrl

### DIFF
--- a/frontend/src/lib/sanitizeBaseUrl.ts
+++ b/frontend/src/lib/sanitizeBaseUrl.ts
@@ -1,7 +1,17 @@
 export function sanitizeBaseUrl(url: string): string {
-  const protocol = new URL(url).protocol
-  if (protocol !== 'http:' && protocol !== 'https:') {
-    throw new Error(`unsupported protocol: ${protocol}`)
+  // Handle relative paths (like '/api')
+  if (url.startsWith('/')) {
+    return url.replace(/\/+$/, '')
   }
-  return url.replace(/\/+$/, '')
+
+  // Handle absolute URLs
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`unsupported protocol: ${parsed.protocol}`)
+    }
+    return url.replace(/\/+$/, '')
+  } catch (error) {
+    throw new Error(`Invalid URL: ${url}`)
+  }
 }

--- a/frontend/tests/baseUrl.spec.ts
+++ b/frontend/tests/baseUrl.spec.ts
@@ -8,10 +8,24 @@ test('baseUrl values with or without trailing slash match', () => {
 })
 
 test('allows http and https protocols', () => {
-  expect(sanitizeBaseUrl('http://api.example.com/')).toBe('http://api.example.com')
-  expect(sanitizeBaseUrl('https://api.example.com/')).toBe('https://api.example.com')
+  expect(sanitizeBaseUrl('http://api.example.com/')).toBe(
+    'http://api.example.com',
+  )
+  expect(sanitizeBaseUrl('https://api.example.com/')).toBe(
+    'https://api.example.com',
+  )
+})
+
+test('handles relative paths', () => {
+  expect(sanitizeBaseUrl('/api')).toBe('/api')
+  expect(sanitizeBaseUrl('/api/')).toBe('/api')
+  expect(sanitizeBaseUrl('/api/v1/')).toBe('/api/v1')
 })
 
 test('throws on unsupported protocol', () => {
   expect(() => sanitizeBaseUrl('ftp://api.example.com')).toThrow()
+})
+
+test('throws on invalid URL format', () => {
+  expect(() => sanitizeBaseUrl('not-a-url')).toThrow()
 })


### PR DESCRIPTION
## Summary
- allow sanitizeBaseUrl to accept relative paths
- validate URL protocol and report invalid URLs
- test relative paths and invalid URL formats

## Testing
- `npm test -- --watchAll=false` *(fails: playwright: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_b_68ab8a0b796c833281b39194e5258b9d