### PR TITLE
chore: add npm registry mirror

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmmirror.com


### PR DESCRIPTION
## Summary
- configure npm to use registry.npmmirror.com for faster/mirrored installs

## Testing
- `npm test -- --watchAll=false` *(fails: vitest not found; registry access blocked)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab905eabdc833290bf1f5eb379fd8f