### PR TITLE
feat: add core TypeScript interfaces

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,53 @@
+// Core petition data matching JSON schema exactly
+export interface PetitionData {
+  county: 'Harris' | 'Dallas' | 'Travis' | 'General'
+  case_no?: string
+  hearing_date?: string // YYYY-MM-DD format
+  petitioner_full_name: string
+  petitioner_address?: string
+  petitioner_phone?: string
+  petitioner_email?: string
+  respondent_full_name: string
+  firearm_surrender?: boolean
+}
+
+// Chat system interfaces
+export interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: Date
+  id: string
+}
+
+// App state management
+export type WizardStep = 'chat' | 'review' | 'generate' | 'download'
+
+export interface AppState {
+  currentStep: WizardStep
+  isLoading: boolean
+  error?: string
+}
+
+// API response types
+export interface ChatResponse {
+  role: 'assistant'
+  content: string
+}
+
+export interface PDFResponse {
+  success: boolean
+  fileUrl?: string
+  error?: string
+}
+
+// Form validation
+export interface ValidationError {
+  field: keyof PetitionData
+  message: string
+}
+
+export interface ValidationResult {
+  isValid: boolean
+  errors: ValidationError[]
+  completionPercentage: number
+}


### PR DESCRIPTION
## Summary
- add PetitionData interface matching petition schema
- define chat, app state, API response, and validation types

## Testing
- `npm test -- --watchAll=false` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab92a79a488332a0b5bab399cc54f7