### PR TITLE
feat: add frontend state constants and utils

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,47 @@
+import type { WizardStep, PetitionData } from './types'
+
+export const COUNTIES = ['Harris', 'Dallas', 'Travis', 'General'] as const
+
+export const WIZARD_STEPS: {
+  step: WizardStep
+  title: string
+  description: string
+}[] = [
+  {
+    step: 'chat',
+    title: 'Information Gathering',
+    description: 'Tell us about your situation',
+  },
+  {
+    step: 'review',
+    title: 'Review Details',
+    description: 'Check and edit your information',
+  },
+  {
+    step: 'generate',
+    title: 'Generate Documents',
+    description: 'Create your legal documents',
+  },
+  {
+    step: 'download',
+    title: 'Download & File',
+    description: 'Get your completed packet',
+  },
+]
+
+export const FIELD_LABELS: Record<keyof PetitionData, string> = {
+  county: 'County',
+  case_no: 'Case Number',
+  hearing_date: 'Hearing Date',
+  petitioner_full_name: 'Your Full Name',
+  petitioner_address: 'Your Address',
+  petitioner_phone: 'Your Phone Number',
+  petitioner_email: 'Your Email Address',
+  respondent_full_name: 'Respondent Full Name',
+  firearm_surrender: 'Firearm Surrender Required',
+}
+
+export const API_ENDPOINTS = {
+  CHAT: '/api/chat',
+  PDF: '/pdf',
+} as const

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -1,0 +1,66 @@
+import { writable, derived } from 'svelte/store'
+import type {
+  PetitionData,
+  AppState,
+  ChatMessage,
+  ValidationResult,
+} from './types'
+
+export const petitionData = writable<Partial<PetitionData>>({})
+
+export const appState = writable<AppState>({
+  currentStep: 'chat',
+  isLoading: false,
+  error: undefined,
+})
+
+export const chatHistory = writable<ChatMessage[]>([])
+
+export const validationStatus = derived(
+  petitionData,
+  ($petitionData): ValidationResult => {
+    const errors: ValidationResult['errors'] = []
+
+    if (!$petitionData.petitioner_full_name) {
+      errors.push({
+        field: 'petitioner_full_name',
+        message: 'Your full name is required',
+      })
+    }
+
+    if (!$petitionData.respondent_full_name) {
+      errors.push({
+        field: 'respondent_full_name',
+        message: 'Respondent full name is required',
+      })
+    }
+
+    const totalFields = 9 // Total number of petition fields
+    const completedFields = Object.keys($petitionData).length
+    const completionPercentage = Math.round(
+      (completedFields / totalFields) * 100,
+    )
+
+    return {
+      isValid:
+        errors.length === 0 &&
+        !!$petitionData.petitioner_full_name &&
+        !!$petitionData.respondent_full_name,
+      errors,
+      completionPercentage,
+    }
+  },
+)
+
+export function quickEscape() {
+  petitionData.set({})
+  chatHistory.set([])
+  appState.set({ currentStep: 'chat', isLoading: false })
+
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem('po-drafter-data')
+    localStorage.removeItem('po-drafter-chat')
+  }
+
+  window.location.href = 'https://weather.com'
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,95 @@
+import type { PetitionData, ValidationResult } from './types'
+import { sanitizeBaseUrl } from './sanitizeBaseUrl'
+
+export async function callChatAPI(messages: any[]): Promise<any> {
+  const baseUrl = sanitizeBaseUrl(
+    (import.meta as any).env.PUBLIC_API_BASE_URL ?? '/api',
+  )
+  const url = `${baseUrl}/chat`
+
+  const apiKey = (import.meta as any).env.PUBLIC_CHAT_API_KEY
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(apiKey ? { 'X-API-Key': apiKey } : {}),
+    },
+    body: JSON.stringify({ messages }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`API Error: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+export function validatePetitionData(
+  data: Partial<PetitionData>,
+): ValidationResult {
+  const errors: ValidationResult['errors'] = []
+
+  if (!data.petitioner_full_name) {
+    errors.push({
+      field: 'petitioner_full_name',
+      message: 'Your full name is required',
+    })
+  }
+
+  if (!data.respondent_full_name) {
+    errors.push({
+      field: 'respondent_full_name',
+      message: 'Respondent full name is required',
+    })
+  }
+
+  if (data.petitioner_email && !isValidEmail(data.petitioner_email)) {
+    errors.push({
+      field: 'petitioner_email',
+      message: 'Please enter a valid email address',
+    })
+  }
+
+  const totalRequiredFields = 2 // petitioner_full_name, respondent_full_name
+  const completedRequiredFields = [
+    data.petitioner_full_name,
+    data.respondent_full_name,
+  ].filter(Boolean).length
+
+  const completionPercentage = Math.round(
+    (completedRequiredFields / totalRequiredFields) * 100,
+  )
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    completionPercentage,
+  }
+}
+
+function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return emailRegex.test(email)
+}
+
+export function saveToLocalStorage(key: string, data: any): void {
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem(key, JSON.stringify(data))
+    } catch (error) {
+      console.warn('Failed to save to localStorage:', error)
+    }
+  }
+}
+
+export function loadFromLocalStorage<T>(key: string, fallback: T): T {
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const stored = localStorage.getItem(key)
+      return stored ? JSON.parse(stored) : fallback
+    } catch (error) {
+      console.warn('Failed to load from localStorage:', error)
+    }
+  }
+  return fallback
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,5 +10,6 @@
     "sourceMap": true,
     "strict": true,
     "moduleResolution": "bundler"
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add constants, stores, and utility helpers for petition drafting
- limit TypeScript compilation to source folder
- generate SvelteKit tsconfig for proper TypeScript support

## Testing
- ✅ `npx tsc --noEmit`
- ⚠️ `npm test -- --watchAll=false` (vitest: not found)
- ⚠️ `npm run dev` (missing vitest)


------
https://chatgpt.com/codex/tasks/task_b_68ab9381301083329cbf56584082179e