### PR TITLE
feat: enhance chat with data extraction and progress tracking

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -167,7 +167,7 @@ def test_chat_endpoint(monkeypatch):
             headers={"X-API-Key": "test-key"},
         )
     assert resp.status_code == 200
-    assert resp.json() == {"role": "assistant", "content": "hi"}
+    assert resp.json() == {"role": "assistant", "content": "hi", "data": {}}
 
   asyncio.run(_run())
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -29,3 +29,5 @@ export const REQUIRED_FIELDS: (keyof PetitionData)[] = [
   'petitioner_full_name',
   'respondent_full_name'
 ]
+
+export const SYSTEM_PROMPT = `You are a compassionate legal assistant helping someone draft a protective order petition. Ask trauma-informed questions in a respectful, logical order. Collect required fields such as petitioner_full_name, respondent_full_name, and county. When you learn any petition information, call the set_petition_data function with the fields. Offer brief legal context and respond with empathy.`

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -32,6 +32,7 @@ export interface AppState {
 export interface ChatResponse {
   role: 'assistant'
   content: string
+  data?: Partial<PetitionData>
 }
 
 export interface PDFResponse {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -6,15 +6,21 @@ import type {
   ValidationError,
   ValidationResult
 } from './types'
-import { API_BASE_URL, REQUIRED_FIELDS } from './constants'
+import { API_BASE_URL, REQUIRED_FIELDS, SYSTEM_PROMPT } from './constants'
 
 export async function sendChat(
   messages: ChatMessage[]
 ): Promise<ChatResponse> {
+  const payload = {
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      ...messages.map(m => ({ role: m.role, content: m.content }))
+    ]
+  }
   const res = await fetch(`${API_BASE_URL}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messages })
+    body: JSON.stringify(payload)
   })
   if (!res.ok) throw new Error(`Chat request failed: ${res.status}`)
   return res.json()


### PR DESCRIPTION
## Summary
- implement GPT tool calling backend to capture petition fields
- add system prompt and auto store merging on the frontend
- show live petition data and completion progress in chat

## Testing
- `npm test -- --watchAll=false` *(fails: vitest: not found; npm install forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aba058cf8c8332882e4e9d5b3b72ed