### PR TITLE
fix: call correct pdf endpoint

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -29,7 +29,7 @@ export async function sendChat(
 export async function generatePDF(
   data: PetitionData
 ): Promise<PDFResponse> {
-  const res = await fetch(`${API_BASE_URL}/generate`, {
+  const res = await fetch(`${API_BASE_URL}/pdf`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- call the backend `/pdf` route when generating PDFs

## Testing
- `npm test -- --watchAll=false` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68abb46c82888332886f8962b74dcc6a