### PR TITLE
feat: add petition upsert tool to chat API

### DIFF
--- a/backend/tests/test_chat_key_fallback.py
+++ b/backend/tests/test_chat_key_fallback.py
@@ -33,8 +33,12 @@ def app(monkeypatch):
 def test_public_key_fallback(monkeypatch, app):
   async def fake_create(self, *args, **kwargs):
     class Msg:
+      role = "assistant"
+      content = "hi"
+      tool_calls = []
+
       def model_dump(self):
-        return {"role": "assistant", "content": "hi"}
+        return {"role": self.role, "content": self.content}
 
     class Choice:
       message = Msg()


### PR DESCRIPTION
## Summary
- add `upsert_petition` tool schema with source message id and confidence
- return chat messages plus extracted petition upserts
- test chat upsert parsing and key fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68abb52aa3188332ac0415b22178a688