### PR TITLE
feat: add API integration and petition helpers

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -5,11 +5,13 @@ export const API_BASE_URL = sanitizeBaseUrl(
   import.meta.env.PUBLIC_API_BASE_URL ?? '/api'
 )
 
-export const WIZARD_STEPS: WizardStep[] = [
-  'chat',
-  'review',
-  'generate',
-  'download'
+export const CHAT_API_KEY = import.meta.env.PUBLIC_CHAT_API_KEY
+
+export const WIZARD_STEPS: any = [
+  { step: 'chat', title: 'Tell Your Story' },
+  { step: 'review', title: 'Review Details' },
+  { step: 'generate', title: 'Create Document' },
+  { step: 'download', title: 'Download' }
 ]
 
 export const FIELD_LABELS: Record<keyof PetitionData, string> = {
@@ -24,10 +26,23 @@ export const FIELD_LABELS: Record<keyof PetitionData, string> = {
   firearm_surrender: 'Firearm Surrender'
 }
 
+export const FIELD_DESCRIPTIONS: Record<keyof PetitionData, string> = {
+  county: 'Which Texas county will you file in?',
+  case_no: 'Leave blank - court will assign',
+  hearing_date: 'Court will schedule this',
+  petitioner_full_name: 'Your legal name as it appears on ID',
+  petitioner_address: 'Where you can receive mail safely',
+  petitioner_phone: 'Best number to reach you',
+  petitioner_email: 'Email for court notifications',
+  respondent_full_name:
+    'Full legal name of the person you need protection from',
+  firearm_surrender: 'Should they surrender any firearms?'
+}
+
 export const REQUIRED_FIELDS: (keyof PetitionData)[] = [
   'county',
   'petitioner_full_name',
   'respondent_full_name'
 ]
 
-export const SYSTEM_PROMPT = `You are a compassionate legal assistant helping someone draft a protective order petition. Ask trauma-informed questions in a respectful, logical order. Collect required fields such as petitioner_full_name, respondent_full_name, and county. When you learn any petition information, call the set_petition_data function with the fields. Offer brief legal context and respond with empathy.`
+export const SYSTEM_PROMPT = `You are a compassionate legal assistant helping someone draft a protective order petition. Ask trauma-informed questions one at a time in a respectful, logical order. Collect required fields such as petitioner_full_name, respondent_full_name, and county. When you learn any petition information, call the set_petition_data function with the fields. Explain briefly why each detail is needed and respond with empathy.`

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -6,7 +6,12 @@ import type {
   ValidationError,
   ValidationResult
 } from './types'
-import { API_BASE_URL, REQUIRED_FIELDS, SYSTEM_PROMPT } from './constants'
+import {
+  API_BASE_URL,
+  REQUIRED_FIELDS,
+  SYSTEM_PROMPT,
+  CHAT_API_KEY
+} from './constants'
 
 export async function sendChat(
   messages: ChatMessage[]
@@ -17,41 +22,97 @@ export async function sendChat(
       ...messages.map(m => ({ role: m.role, content: m.content }))
     ]
   }
-  const res = await fetch(`${API_BASE_URL}/chat`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  })
-  if (!res.ok) throw new Error(`Chat request failed: ${res.status}`)
-  return res.json()
+  try {
+    const res = await fetch(`${API_BASE_URL}/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(CHAT_API_KEY ? { 'X-API-Key': CHAT_API_KEY } : {})
+      },
+      body: JSON.stringify(payload)
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`Chat request failed: ${res.status} ${text}`)
+    }
+    return res.json()
+  } catch (err) {
+    throw err
+  }
 }
 
 export async function generatePDF(
   data: PetitionData
 ): Promise<PDFResponse> {
-  const res = await fetch(`${API_BASE_URL}/pdf`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data)
+  try {
+    const res = await fetch(`${API_BASE_URL}/pdf`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    })
+    if (!res.ok) return { success: false, error: `Status ${res.status}` }
+    const blob = await res.blob()
+    const fileUrl = URL.createObjectURL(blob)
+    return { success: true, fileUrl }
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}
+
+export function getCollectedFields(
+  data: PetitionData
+): {
+  collected: (keyof PetitionData)[]
+  missing: (keyof PetitionData)[]
+  requiredMissing: (keyof PetitionData)[]
+} {
+  const allFields = Object.keys(data) as (keyof PetitionData)[]
+  const collected = allFields.filter(field => {
+    const value = data[field]
+    return value !== undefined && value !== null && value !== ''
   })
-  if (!res.ok) return { success: false, error: `Status ${res.status}` }
-  return res.json()
+  const missing = allFields.filter(field => !collected.includes(field))
+  const requiredMissing = REQUIRED_FIELDS.filter(field => !collected.includes(field))
+  return { collected, missing, requiredMissing }
+}
+
+export function getNextSuggestedField(
+  data: PetitionData
+): keyof PetitionData | null {
+  const { collected } = getCollectedFields(data)
+  const priorityOrder: (keyof PetitionData)[] = [
+    'county',
+    'petitioner_full_name',
+    'respondent_full_name',
+    'petitioner_address',
+    'petitioner_phone',
+    'petitioner_email'
+  ]
+  for (const field of priorityOrder) {
+    if (!collected.includes(field)) return field
+  }
+  return null
+}
+
+export function canProceedToReview(data: PetitionData): boolean {
+  const validation = validatePetition(data)
+  return validation.isValid
 }
 
 export function validatePetition(
   data: PetitionData
 ): ValidationResult {
-  const errors: ValidationError[] = []
-  for (const field of REQUIRED_FIELDS) {
-    if (!data[field]) {
-      errors.push({ field, message: `${field} is required` })
-    }
-  }
-  const filled = Object.values(data).filter(v => v !== undefined && v !== '').length
-  const completion = Math.round((filled / Object.keys(data).length) * 100)
+  const { collected, requiredMissing } = getCollectedFields(data)
+  const errors: ValidationError[] = requiredMissing.map(field => ({
+    field,
+    message: `${field} is required`
+  }))
+  const completionPercentage = Math.round(
+    (collected.length / Object.keys(data).length) * 100
+  )
   return {
     isValid: errors.length === 0,
     errors,
-    completionPercentage: completion
+    completionPercentage
   }
 }


### PR DESCRIPTION
## Summary
- add CHAT_API_KEY and field descriptions
- expose wizard step titles and richer system prompt
- enhance chat, PDF generation and petition progress helpers

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option --watchAll)*
- `npm test` *(fails: Cannot convert undefined or null to object)*
- `npm run dev`
- `npx tsc --noEmit` *(fails: Cannot find name 'process')*

------
https://chatgpt.com/codex/tasks/task_b_68acb7ece7a88332b22cd4dea4d0b76e