### PR TITLE
chore: add sample environment configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+# Local development environment variables for PO Drafter
+# Never commit real secrets to this file
+
+OPENAI_API_KEY=your_openai_api_key_here
+CHAT_API_KEY=dev_secure_random_key
+PUBLIC_CHAT_API_KEY=dev_secure_random_key
+ALLOWED_ORIGINS=http://localhost:5173,https://your-domain.vercel.app
+PUBLIC_API_BASE_URL=http://localhost:8080/api
+REDIS_URL=redis://localhost:6379/0
+ENVIRONMENT=development

--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,24 @@
 # Environment configuration for PO Drafter
-OPENAI_API_KEY=
-# Allowed CORS origins (comma-separated URLs, wildcards * are rejected)
-ALLOWED_ORIGINS=http://localhost:5173
-REDIS_URL=redis://localhost:6379/0
-# Shared secret for /api/chat
-CHAT_API_KEY=
-# Frontend copy; must match CHAT_API_KEY for local development
-PUBLIC_CHAT_API_KEY=
+# Copy this file to .env and replace values for your setup
 
-# Example environment variables for local development
-# Base path for the backend API used by the SvelteKit frontend
-# e.g. /api or https://your-deploy.com/api
+# OpenAI API Key (required for chat functionality)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Chat API Key - secure random string for frontend-backend communication
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+CHAT_API_KEY=your_secure_random_key_here
+
+# Frontend environment variable (must match CHAT_API_KEY exactly)
+PUBLIC_CHAT_API_KEY=your_secure_random_key_here
+
+# CORS Origins - comma-separated exact URLs (no wildcards)
+ALLOWED_ORIGINS=http://localhost:5173,https://your-domain.vercel.app
+
+# Frontend API base URL
 PUBLIC_API_BASE_URL=/api
+
+# Redis for rate limiting (optional - has in-memory fallback)
+REDIS_URL=redis://localhost:6379/0
+
+# Environment type
+ENVIRONMENT=development


### PR DESCRIPTION
## Summary
- document required environment variables and defaults
- add sample development `.env`

## Testing
- `timeout 5s uvicorn backend.main:app --port 8080` *(fails: OpenAI connectivity check)*
- `curl -sS http://localhost:8080/health` *(fails: couldn't connect to server)*
- `cd frontend && timeout 5s npm run dev`
- `pytest`
- `cd frontend && npm test -- --watchAll=false` *(fails: unknown option `--watchAll`)*

------
https://chatgpt.com/codex/tasks/task_b_68acbbb46cdc83328dd68a31e2f54ee0