### PR TITLE
fix: remove system prompt from frontend chat requests

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -9,7 +9,6 @@ import type {
 import {
   API_BASE_URL,
   REQUIRED_FIELDS,
-  SYSTEM_PROMPT,
   CHAT_API_KEY
 } from './constants'
 
@@ -17,10 +16,7 @@ export async function sendChat(
   messages: ChatMessage[]
 ): Promise<ChatResponse> {
   const payload = {
-    messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
-      ...messages.map(m => ({ role: m.role, content: m.content }))
-    ]
+    messages: messages.map(m => ({ role: m.role, content: m.content }))
   }
   try {
     const res = await fetch(`${API_BASE_URL}/chat`, {


### PR DESCRIPTION
## Summary
- drop system role from `sendChat` payload so backend controls prompts

## Testing
- `npm test -- --watchAll=false` *(fails: CACError: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ace5126ce083328544a3d808138889