### PR TITLE
fix: verify template checksums

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -65,7 +65,7 @@ SENSITIVE_PATHS = {"/api/chat", "/pdf"}
 DISALLOWED_PATTERNS = [re.compile(p, re.IGNORECASE) for p in ["<script", "javascript:", "data:"]]
 
 # SHA256 checksums for standard form templates
-TEMPLATE_CHECKSUMS = {
+TEMPLATE_CHECKSUMS: dict[str, str] = {
   "dallas.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",
   "harris.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",
   "travis.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",

--- a/backend/tests/test_template_checksums.py
+++ b/backend/tests/test_template_checksums.py
@@ -7,8 +7,8 @@ from backend.main import TEMPLATE_CHECKSUMS, FORMS_DIR
 
 
 def test_template_checksums():
+  expected: dict[str, str] = {}
   for path in FORMS_DIR.glob("*.pdf"):
     with open(path, "rb") as f:
-      actual = hashlib.sha256(f.read()).hexdigest()
-    expected = TEMPLATE_CHECKSUMS.get(path.name)
-    assert expected == actual, f"{path.name} checksum mismatch"
+      expected[path.name] = hashlib.sha256(f.read()).hexdigest()
+  assert TEMPLATE_CHECKSUMS == expected


### PR DESCRIPTION
## Summary
- add type annotation for template checksum map and record computed hashes
- tighten checksum tests to ensure template integrity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ace72c84748332a39c69b3ca375d5d