### PR TITLE
feat: require API key for PDF endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -372,8 +372,15 @@ async def redis_health():
 
 
 @app.post("/pdf")
-async def generate_pdf(data: dict) -> StreamingResponse:
+async def generate_pdf(data: dict, request: Request) -> StreamingResponse:
     """Generate PDF packet from petition data."""
+    provided = request.headers.get("X-API-Key")
+    if CHAT_API_KEY is None:
+        logger.error("CHAT_API_KEY is not set")
+        raise HTTPException(status_code=500, detail="Server misconfiguration")
+    if not provided or provided != CHAT_API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
     if not isinstance(data, dict):
         raise HTTPException(status_code=400, detail="Invalid request body")
 

--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -40,7 +40,10 @@ def test_chunked_request_too_large():
       resp = await client.post(
         "/pdf",
         content=gen(),
-        headers={"Content-Type": "application/json"},
+        headers={
+          "Content-Type": "application/json",
+          "X-API-Key": "test-key",
+        },
       )
     assert resp.status_code == 413
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -123,7 +123,9 @@ def test_pdf_generation(monkeypatch):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-        resp = await client.post("/pdf", json=data)
+        resp = await client.post(
+            "/pdf", json=data, headers={"X-API-Key": "test-key"}
+        )
     assert resp.status_code == 200
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         pdf_bytes = zf.read("petition.pdf")
@@ -138,6 +140,50 @@ def test_pdf_generation(monkeypatch):
         "PetitionerEmail": "jane@example.com",
         "RespondentName": "John Doe",
     }
+
+  asyncio.run(_run())
+
+
+def test_pdf_missing_api_key():
+  async def _run():
+    data = {
+        "county": "General",
+        "case_no": "123",
+        "hearing_date": "2024-01-01",
+        "petitioner_full_name": "Jane Doe",
+        "petitioner_address": "1 Main St",
+        "petitioner_phone": "555-0000",
+        "petitioner_email": "jane@example.com",
+        "respondent_full_name": "John Doe",
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.post("/pdf", json=data)
+    assert resp.status_code == 401
+
+  asyncio.run(_run())
+
+
+def test_pdf_invalid_api_key():
+  async def _run():
+    data = {
+        "county": "General",
+        "case_no": "123",
+        "hearing_date": "2024-01-01",
+        "petitioner_full_name": "Jane Doe",
+        "petitioner_address": "1 Main St",
+        "petitioner_phone": "555-0000",
+        "petitioner_email": "jane@example.com",
+        "respondent_full_name": "John Doe",
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.post(
+            "/pdf", json=data, headers={"X-API-Key": "wrong"}
+        )
+    assert resp.status_code == 401
 
   asyncio.run(_run())
 
@@ -331,7 +377,9 @@ def test_pdf_invalid_schema():
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-        resp = await client.post("/pdf", json=data)
+        resp = await client.post(
+            "/pdf", json=data, headers={"X-API-Key": "test-key"}
+        )
     assert resp.status_code == 400
 
   asyncio.run(_run())


### PR DESCRIPTION
## Summary
- require X-API-Key auth for /pdf
- test PDF endpoint authentication

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ace8312b748332988ac5ef0f32e002