### PR TITLE
fix: remove debug logging

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -78,7 +78,6 @@
 
       // Extract and merge petition data
       if (response.data && Object.keys(response.data).length > 0) {
-        console.log('Extracting petition data:', response.data)
         petitionData.update(current => {
           const updated = { ...current }
           for (const [key, value] of Object.entries(response.data!)) {
@@ -99,7 +98,7 @@
 
       chatMessages.update(m => [...m, assistantMsg])
     } catch (err) {
-      console.error('Chat error:', err)
+      if (import.meta.env.DEV) console.error('Chat error:', err)
       const errorMsg = err instanceof Error ? err.message : 'Chat request failed'
       appState.update(s => ({ ...s, error: errorMsg }))
     } finally {


### PR DESCRIPTION
## Summary
- remove console log leaking petition data in AppLayout
- guard chat error logging for development only

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68ace951e50483328675a3f9733dabf2