### PR TITLE
feat: add security headers middleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -310,6 +310,13 @@ app.add_middleware(
 )
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1"])
 
+@app.middleware("http")
+async def set_security_headers(request: Request, call_next):
+  response = await call_next(request)
+  response.headers["Content-Security-Policy"] = "default-src 'self'"
+  response.headers["X-Content-Type-Options"] = "nosniff"
+  return response
+
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,45 @@
+import os
+import asyncio
+import httpx
+import pytest
+
+os.environ["OPENAI_API_KEY"] = "test"
+os.environ["CHAT_API_KEY"] = "test-key"
+
+from backend.main import app
+
+
+class DummyRedis:
+  async def zremrangebyscore(self, *args, **kwargs):
+    pass
+
+  async def zcard(self, *args, **kwargs):
+    return 0
+
+  async def zadd(self, *args, **kwargs):
+    pass
+
+  async def expire(self, *args, **kwargs):
+    pass
+
+  async def ping(self, *args, **kwargs):
+    return True
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+  monkeypatch.setattr("backend.main.redis_client", DummyRedis())
+
+
+@pytest.mark.parametrize("path", ["/health", "/redis/health"])
+def test_security_headers(path):
+  async def _run():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(path)
+    assert resp.headers["content-security-policy"] == "default-src 'self'"
+    assert resp.headers["x-content-type-options"] == "nosniff"
+
+  asyncio.run(_run())
+


### PR DESCRIPTION
## Summary
- add HTTP middleware to set Content-Security-Policy and X-Content-Type-Options headers
- test security headers on health endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acf0a257988332a588bccd0528e41d