### PR TITLE
feat: add request timeout support to chat API

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -74,7 +74,7 @@
     appState.update(s => ({ ...s, isLoading: true, error: undefined }))
 
     try {
-      const response = await sendChat(get(chatMessages))
+      const response = await sendChat(get(chatMessages), 10000)
 
       // Extract and merge petition data
       if (response.data && Object.keys(response.data).length > 0) {

--- a/frontend/tests/sendChat.test.ts
+++ b/frontend/tests/sendChat.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ChatMessage } from '../src/lib/types'
+import { sendChat } from '../src/lib/utils'
+
+const originalFetch = global.fetch
+
+describe('sendChat', () => {
+  it('aborts the request after timeout', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn(
+      (_url, options: any) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          )
+        }),
+    )
+    global.fetch = fetchMock as any
+
+    const messages: ChatMessage[] = [{ role: 'user', content: 'hi' }]
+    const promise = sendChat(messages, 10)
+    vi.runAllTimers()
+    await expect(promise).rejects.toThrow(/aborted/)
+    expect(fetchMock).toHaveBeenCalled()
+
+    global.fetch = originalFetch
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- add abortable timeout to `sendChat`
- call `sendChat` with timeout in `AppLayout`
- test `sendChat` timeout behavior

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68acf18ae1c883328a742129f587085b