### PR TITLE
feat: add chat wizard heading and test

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -142,7 +142,8 @@
   {#if $appState.error}
     <p class="text-red-600 mb-2">{$appState.error}</p>
   {/if}
-<nav class="mb-4 flex justify-between">
+  <h1 class="text-xl font-bold mb-4">PO Drafter Chat Wizard</h1>
+  <nav class="mb-4 flex justify-between">
   {#each WIZARD_STEPS as { step, title }}
     <span class:text-blue-600={step === $appState.currentStep}>
       {title}

--- a/frontend/tests/page.test.ts
+++ b/frontend/tests/page.test.ts
@@ -5,6 +5,10 @@ import Page from '../src/routes/+page.svelte'
 describe('Page', () => {
   it('renders heading', () => {
     render(Page)
-    expect(screen.getByText('PO Drafter Chat Wizard')).toBeInTheDocument()
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'PO Drafter Chat Wizard'
+    })
+    expect(heading).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- add PO Drafter heading to layout
- assert heading in page test

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68acf2e46bc483328fa9dc8e23173f98