### PR TITLE
feat: improve chat accessibility with live region

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -157,6 +157,9 @@
         <div
           class="chat-area mb-4 h-64 overflow-y-auto border p-2 rounded"
           bind:this={chatContainer}
+          aria-live="polite"
+          role="log"
+          aria-atomic="false"
         >
           {#each $chatMessages as msg}
             <div


### PR DESCRIPTION
## Summary
- ensure chat messages are announced to assistive tech with `aria-live="polite"` and `role="log"`
- mark updates as non-atomic so screen readers only read new messages

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*
- `npx svelte-check` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_b_68acf3e6b1ac8332ad46081022373462