### PR TITLE
feat: expose wizard step keys and steps

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -7,12 +7,14 @@ export const API_BASE_URL = sanitizeBaseUrl(
 
 export const CHAT_API_KEY = import.meta.env.PUBLIC_CHAT_API_KEY
 
-export const WIZARD_STEPS: any = [
+export const WIZARD_STEPS: { step: WizardStep, title: string }[] = [
   { step: 'chat', title: 'Tell Your Story' },
   { step: 'review', title: 'Review Details' },
   { step: 'generate', title: 'Create Document' },
   { step: 'download', title: 'Download' }
 ]
+
+export const WIZARD_STEP_KEYS: WizardStep[] = WIZARD_STEPS.map(({ step }) => step)
 
 export const FIELD_LABELS: Record<keyof PetitionData, string> = {
   county: 'County',

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -5,7 +5,7 @@ import type {
   ChatMessage,
   WizardStep
 } from './types'
-import { WIZARD_STEPS } from './constants'
+import { WIZARD_STEP_KEYS } from './constants'
 
 export const petitionData = writable<PetitionData>({
   county: 'General',
@@ -28,16 +28,16 @@ export function goToStep(step: WizardStep) {
 
 export function nextStep() {
   appState.update(state => {
-    const idx = WIZARD_STEPS.indexOf(state.currentStep)
-    const next = WIZARD_STEPS[idx + 1] ?? state.currentStep
+    const idx = WIZARD_STEP_KEYS.indexOf(state.currentStep)
+    const next = WIZARD_STEP_KEYS[idx + 1] ?? state.currentStep
     return { ...state, currentStep: next }
   })
 }
 
 export function prevStep() {
   appState.update(state => {
-    const idx = WIZARD_STEPS.indexOf(state.currentStep)
-    const prev = WIZARD_STEPS[idx - 1] ?? state.currentStep
+    const idx = WIZARD_STEP_KEYS.indexOf(state.currentStep)
+    const prev = WIZARD_STEP_KEYS[idx - 1] ?? state.currentStep
     return { ...state, currentStep: prev }
   })
 }


### PR DESCRIPTION
## Summary
- export WIZARD_STEP_KEYS alongside detailed WIZARD_STEPS
- use WIZARD_STEP_KEYS for step navigation lookups

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm exec svelte-kit sync`
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68acf63770e48332baa30276706bc023