### PR TITLE
feat(frontend): add PDF URL revoker

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -26,6 +26,7 @@
 
   let userInput = ''
   let chatContainer: HTMLDivElement
+  let revokePdf: (() => void) | null = null
   const fieldEntries: [keyof PetitionData, string][] = Object.entries(
     FIELD_LABELS
   ) as [keyof PetitionData, string][]
@@ -119,8 +120,10 @@
   async function handleGenerate() {
     appState.update(s => ({ ...s, isLoading: true, error: undefined }))
     try {
+      revokePdf?.()
       const res = await generatePDF(get(petitionData))
       if (res.success && res.fileUrl) {
+        revokePdf = res.revoke ?? null
         pdfUrl.set(res.fileUrl)
         nextStep()
       } else {
@@ -135,6 +138,12 @@
     } finally {
       appState.update(s => ({ ...s, isLoading: false }))
     }
+  }
+
+  function handleDownloadBack() {
+    revokePdf?.()
+    pdfUrl.set(null)
+    prevStep()
   }
 </script>
 
@@ -277,7 +286,7 @@
       </a>
     {/if}
     <div class="mt-4">
-      <button class="bg-gray-200 px-3 py-1 rounded" on:click={prevStep}>
+      <button class="bg-gray-200 px-3 py-1 rounded" on:click={handleDownloadBack}>
         Back
       </button>
     </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface ChatResponse {
 export interface PDFResponse {
   success: boolean
   fileUrl?: string
+  revoke?: () => void
   error?: string
 }
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -49,7 +49,8 @@ export async function generatePDF(data: PetitionData): Promise<PDFResponse> {
     if (!res.ok) return { success: false, error: `Status ${res.status}` }
     const blob = await res.blob()
     const fileUrl = URL.createObjectURL(blob)
-    return { success: true, fileUrl }
+    const revoke = () => URL.revokeObjectURL(fileUrl)
+    return { success: true, fileUrl, revoke }
   } catch (err) {
     return { success: false, error: (err as Error).message }
   }


### PR DESCRIPTION
## Summary
- return revoker from `generatePDF` and type it in `PDFResponse`
- track and call revoker in `AppLayout` when generating or leaving download step

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option --watchAll)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68acf800b91083329637cee8aa5a6439