### PR TITLE
docs: clarify /api/chat endpoint section header

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -456,7 +456,7 @@ async def generate_pdf(data: dict, request: Request) -> StreamingResponse:
     )
 
 
-# ✅ Add your OpenAI chat endpoint below
+# OpenAI chat endpoint (/api/chat)
 
 SYSTEM_PROMPT = """You are a trauma-informed legal assistant helping create protective order petitions in Texas. You are compassionate, patient, and professional.
 


### PR DESCRIPTION
## Summary
- clarify section header for `/api/chat` OpenAI endpoint implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad034e2b6c8332a56ca2d962aa9169