### PR TITLE
fix: harden string sanitization

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import html
+import bleach
 import io
 import json
 import logging
@@ -82,8 +82,8 @@ FALLBACK_MAX_IPS = 1000
 FALLBACK_IP_TTL = RATE_WINDOW * 5
 
 def sanitize_string(value: str) -> str:
-  """Basic XSS protection and length enforcement for user-provided strings."""
-  cleaned = html.escape(value, quote=True)
+  """Sanitize user-provided strings to mitigate XSS risks."""
+  cleaned = bleach.clean(value, strip=True)
   cleaned = re.sub(r"[\x00-\x1f\x7f-\x9f]", "", cleaned)
   cleaned = re.sub(r"(javascript:|data:)", "", cleaned, flags=re.IGNORECASE)
   return cleaned.strip()[:MAX_FIELD_LENGTH]

--- a/backend/tests/test_xss_sanitization.py
+++ b/backend/tests/test_xss_sanitization.py
@@ -1,0 +1,16 @@
+import pytest
+
+from backend.main import sanitize_string
+
+
+@pytest.mark.parametrize(
+  "payload,expected",
+  [
+    ("<script>alert('x')</script>", "alert('x')"),
+    ("<img src=x onerror=alert(1)>", ""),
+    ("javascript:alert(1)", "alert(1)"),
+    ("data:text/html,<script>alert(1)</script>", "text/html,alert(1)"),
+  ],
+)
+def test_sanitize_string(payload, expected):
+  assert sanitize_string(payload) == expected

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ jinja2==3.1.3
 fpdf2==2.7.8
 redis==5.0.1
 fakeredis==2.21.0
+bleach==6.1.0


### PR DESCRIPTION
## Summary
- replace custom string sanitizer with `bleach`
- add test coverage for common XSS payloads

## Testing
- `pip install bleach==6.1.0` *(fails: Could not find a version that satisfies the requirement)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_b_68ad03e437b083329aed63a032b91fa9