### PR TITLE
feat: add API key to PDF generation

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -44,7 +44,10 @@ export async function generatePDF(data: PetitionData): Promise<PDFResponse> {
   try {
     const res = await fetch(`${API_BASE_URL}/pdf`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(CHAT_API_KEY ? { 'X-API-Key': CHAT_API_KEY } : {}),
+      },
       body: JSON.stringify(data),
     })
     if (!res.ok) return { success: false, error: `Status ${res.status}` }

--- a/frontend/tests/generatePDF.test.ts
+++ b/frontend/tests/generatePDF.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { PetitionData } from '../src/lib/types'
+
+const originalFetch = global.fetch
+
+describe('generatePDF', () => {
+  it('returns success when X-API-Key header present', async () => {
+    vi.stubEnv('PUBLIC_CHAT_API_KEY', 'test-key')
+    const { generatePDF } = await import('../src/lib/utils')
+
+    const fetchMock = vi.fn().mockImplementation((_url, options: any) => {
+      if (options.headers['X-API-Key'] === 'test-key') {
+        return Promise.resolve({
+          ok: true,
+          blob: () => Promise.resolve(new Blob(['pdf'])),
+        })
+      }
+      return Promise.resolve({ ok: false, status: 401 })
+    })
+    global.fetch = fetchMock as any
+
+    const resp = await generatePDF({} as PetitionData)
+    expect(resp.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'test-key' }),
+      }),
+    )
+
+    global.fetch = originalFetch
+    vi.unstubAllEnvs()
+  })
+})


### PR DESCRIPTION
## Summary
- send `X-API-Key` header when generating a PDF
- test PDF generation request includes API key header

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npx svelte-kit sync`
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68adca1334188332852cd35014e39d73