### PR TITLE
test: add store navigation tests

### DIFF
--- a/frontend/tests/stores.test.ts
+++ b/frontend/tests/stores.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { get } from 'svelte/store'
+import { appState, nextStep, prevStep, goToStep } from '../src/lib/stores'
+
+describe('wizard navigation', () => {
+  beforeEach(() => {
+    appState.set({ currentStep: 'chat', isLoading: false })
+  })
+
+  it('moves forward through steps and stops at last', () => {
+    expect(get(appState).currentStep).toBe('chat')
+    nextStep()
+    expect(get(appState).currentStep).toBe('review')
+    nextStep()
+    expect(get(appState).currentStep).toBe('generate')
+    nextStep()
+    expect(get(appState).currentStep).toBe('download')
+    nextStep()
+    expect(get(appState).currentStep).toBe('download')
+  })
+
+  it('moves backward through steps and stops at first', () => {
+    goToStep('download')
+    expect(get(appState).currentStep).toBe('download')
+    prevStep()
+    expect(get(appState).currentStep).toBe('generate')
+    prevStep()
+    expect(get(appState).currentStep).toBe('review')
+    prevStep()
+    expect(get(appState).currentStep).toBe('chat')
+    prevStep()
+    expect(get(appState).currentStep).toBe('chat')
+  })
+
+  it('goToStep sets specified step', () => {
+    goToStep('generate')
+    expect(get(appState).currentStep).toBe('generate')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add Vitest coverage for appState navigation
- ensure nextStep and prevStep respect boundaries

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68add2d22bec8332b7e55b8f3ce55f87