### PR TITLE
fix: block vbscript and file schemes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -64,7 +64,10 @@ ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 # Use PUBLIC_CHAT_API_KEY as fallback for local development
 CHAT_API_KEY = os.getenv("CHAT_API_KEY") or os.getenv("PUBLIC_CHAT_API_KEY")
 SENSITIVE_PATHS = {"/api/chat", "/pdf"}
-DISALLOWED_PATTERNS = [re.compile(p, re.IGNORECASE) for p in ["<script", "javascript:", "data:"]]
+DISALLOWED_PATTERNS = [
+  re.compile(p, re.IGNORECASE)
+  for p in ["<script", "javascript:", "data:", "vbscript:", "file:"]
+]
 
 # SHA256 checksums for standard form templates
 TEMPLATE_CHECKSUMS: dict[str, str] = {

--- a/backend/tests/test_xss_sanitization.py
+++ b/backend/tests/test_xss_sanitization.py
@@ -1,6 +1,12 @@
+import os
+import asyncio
+import httpx
 import pytest
 
-from backend.main import sanitize_string
+os.environ["OPENAI_API_KEY"] = "test"
+os.environ["CHAT_API_KEY"] = "test-key"
+
+from backend.main import sanitize_string, app
 
 
 @pytest.mark.parametrize(
@@ -14,3 +20,26 @@ from backend.main import sanitize_string
 )
 def test_sanitize_string(payload, expected):
   assert sanitize_string(payload) == expected
+
+
+@pytest.mark.parametrize(
+  "payload",
+  [
+    "vbscript:alert(1)",
+    "file://etc/passwd",
+  ],
+)
+def test_chat_rejects_disallowed_schemes(payload):
+  async def _run():
+    messages = [{"role": "user", "content": payload}]
+    async with httpx.AsyncClient(
+      transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+      resp = await client.post(
+        "/api/chat",
+        json={"messages": messages},
+        headers={"X-API-Key": "test-key"},
+      )
+    assert resp.status_code == 400
+
+  asyncio.run(_run())


### PR DESCRIPTION
## Summary
- extend disallowed URL patterns to include `vbscript:` and `file:`
- test chat endpoint rejects messages with these new schemes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68adfbdff3f88332a92ac35db1953314