### PR TITLE
feat: add request correlation middleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from .middleware.rate_limit import (
   fallback_limiter,
 )
 from .middleware.security import BodySizeLimitMiddleware, log_requests, set_security_headers
+from .middleware.correlation import add_correlation_id
 from .utils.sanitization import sanitize_string, CoverLetterContext
 from .utils.validation import get_allowed_origins, reload_schema, MAX_REQUEST_SIZE
 from .services.openai_client import validate_environment
@@ -35,6 +36,7 @@ app.add_middleware(
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1"])
 app.middleware("http")(set_security_headers)
 app.middleware("http")(log_requests)
+app.middleware("http")(add_correlation_id)
 
 
 @app.on_event("startup")

--- a/backend/middleware/correlation.py
+++ b/backend/middleware/correlation.py
@@ -1,0 +1,14 @@
+import uuid
+from contextvars import ContextVar
+from fastapi import Request
+from typing import Callable
+from starlette.responses import Response
+
+request_id: ContextVar[str] = ContextVar("request_id")
+
+async def add_correlation_id(request: Request, call_next: Callable) -> Response:
+  correlation_id = request.headers.get("X-Correlation-ID", str(uuid.uuid4()))
+  request_id.set(correlation_id)
+  response: Response = await call_next(request)
+  response.headers["X-Correlation-ID"] = correlation_id
+  return response

--- a/backend/middleware/security.py
+++ b/backend/middleware/security.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .auth import get_client_ip
+from .correlation import request_id
 from ..utils.validation import MAX_REQUEST_SIZE
 
 logger = logging.getLogger(__name__)
@@ -58,11 +59,12 @@ async def log_requests(request: Request, call_next):
     log_ip = "redacted" if path in SENSITIVE_PATHS else ip
     log_path = "redacted" if path in SENSITIVE_PATHS else path
     logger.exception(
-      "Error processing %s %s from %s in %.2fms",
+      "Error processing %s %s from %s in %.2fms [id=%s]",
       request.method,
       log_path,
       log_ip,
       duration,
+      request_id.get(None),
     )
     raise
   duration = (time.time() - start) * 1000
@@ -70,11 +72,12 @@ async def log_requests(request: Request, call_next):
   log_ip = "redacted" if path in SENSITIVE_PATHS else ip
   log_path = "redacted" if path in SENSITIVE_PATHS else path
   logger.info(
-    "%s %s from %s -> %s in %.2fms",
+    "%s %s from %s -> %s in %.2fms [id=%s]",
     request.method,
     log_path,
     log_ip,
     response.status_code,
     duration,
+    request_id.get(None),
   )
   return response


### PR DESCRIPTION
## Summary
- add correlation ID middleware for request tracing
- include correlation IDs in request logs
- test correlation header behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae058a7b108332971012a3a568f46b