### PR TITLE
feat: add worker queue for PDF generation

### DIFF
--- a/backend/services/pdf_service.py
+++ b/backend/services/pdf_service.py
@@ -1,4 +1,5 @@
 import io
+import asyncio
 import zipfile
 from fastapi import HTTPException
 
@@ -6,7 +7,7 @@ from ..utils.sanitization import sanitize_string
 from .template_service import FIELD_MAP, get_template_file, verify_template_integrity
 
 
-def generate_pdf(data: dict) -> io.BytesIO:
+def _generate_pdf_sync(data: dict) -> io.BytesIO:
   from backend import main as main_module
 
   county = data.get("county", "General")
@@ -40,3 +41,7 @@ def generate_pdf(data: dict) -> io.BytesIO:
     zf.writestr("petition.pdf", pdf_bytes.getvalue())
   zip_bytes.seek(0)
   return zip_bytes
+
+
+async def generate_pdf(data: dict) -> io.BytesIO:
+  return await asyncio.to_thread(_generate_pdf_sync, data)

--- a/backend/tests/test_pdf_queue.py
+++ b/backend/tests/test_pdf_queue.py
@@ -1,0 +1,71 @@
+import asyncio
+import io
+import zipfile
+
+import httpx
+import os
+import pytest
+
+os.environ["OPENAI_API_KEY"] = "test"
+os.environ["CHAT_API_KEY"] = "test-key"
+
+from backend.main import app
+from backend.services.pdf_service import generate_pdf
+
+class DummyRedis:
+  async def zremrangebyscore(self, *args, **kwargs):
+    pass
+
+  async def zcard(self, *args, **kwargs):
+    return 0
+
+  async def zadd(self, *args, **kwargs):
+    pass
+
+  async def expire(self, *args, **kwargs):
+    pass
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+  monkeypatch.setattr("backend.main.redis_client", DummyRedis())
+
+
+def test_route_enqueues_and_returns_zip(monkeypatch):
+  called = {}
+
+  async def fake_enqueue(func, *args, **kwargs):
+    called["func"] = func
+    called["args"] = args
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    zip_bytes = io.BytesIO()
+    with zipfile.ZipFile(zip_bytes, "w") as zf:
+      zf.writestr("petition.pdf", b"dummy")
+    zip_bytes.seek(0)
+    future.set_result(zip_bytes)
+    return future
+
+  monkeypatch.setattr("backend.api.pdf.queue.enqueue", fake_enqueue)
+
+  data = {
+    "county": "General",
+    "case_no": "123",
+    "hearing_date": "2024-01-01",
+    "petitioner_full_name": "Jane Doe",
+    "petitioner_address": "1 Main St",
+    "petitioner_phone": "555-0000",
+    "petitioner_email": "jane@example.com",
+    "respondent_full_name": "John Doe",
+  }
+
+  async def _run():
+    async with httpx.AsyncClient(
+      transport=httpx.ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+      return await client.post("/pdf", json=data, headers={"X-API-Key": "test-key"})
+
+  resp = asyncio.run(_run())
+  assert resp.status_code == 200
+  assert called["func"] is generate_pdf
+  with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+    assert zf.read("petition.pdf") == b"dummy"

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,31 @@
+import asyncio
+from typing import Any, Awaitable, Callable
+
+class WorkerQueue:
+  def __init__(self) -> None:
+    self._queue: asyncio.Queue[tuple[Callable[..., Awaitable[Any]], tuple, dict, asyncio.Future]] = asyncio.Queue()
+    self._worker_started = False
+
+  async def _start_worker(self) -> None:
+    if not self._worker_started:
+      asyncio.create_task(self._worker())
+      self._worker_started = True
+
+  async def _worker(self) -> None:
+    while True:
+      func, args, kwargs, future = await self._queue.get()
+      try:
+        result = await func(*args, **kwargs)
+        future.set_result(result)
+      except Exception as exc:
+        future.set_exception(exc)
+      self._queue.task_done()
+
+  async def enqueue(self, func: Callable[..., Awaitable[Any]], *args, **kwargs) -> asyncio.Future:
+    await self._start_worker()
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    await self._queue.put((func, args, kwargs, future))
+    return future
+
+queue = WorkerQueue()


### PR DESCRIPTION
## Summary
- introduce asyncio worker queue for CPU-bound jobs
- offload PDF generation into worker threads
- enqueue PDF requests via `/pdf` route
- test queue behavior and zip response

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ae06aaf3cc83329abba37a66470412