### PR TITLE
feat: add rate limiter factory

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,9 +8,9 @@ from .api import chat, pdf, health
 from .middleware.rate_limit import (
   RateLimitMiddleware,
   redis_client,
-  fallback_store,
-  fallback_active,
-  fallback_limiter,
+  RedisRateLimiter,
+  InMemoryRateLimiter,
+  RateLimiterProtocol,
 )
 from .middleware.security import BodySizeLimitMiddleware, log_requests, set_security_headers
 from .middleware.correlation import add_correlation_id
@@ -19,32 +19,42 @@ from .utils.validation import get_allowed_origins, reload_schema, MAX_REQUEST_SI
 from .services.openai_client import validate_environment
 from .services.template_service import TEMPLATE_CHECKSUMS, FORMS_DIR
 
+
 RATE_LIMIT = 100
 RATE_WINDOW = 60
 FALLBACK_MAX_IPS = 1000
 FALLBACK_IP_TTL = RATE_WINDOW * 5
 
-app = FastAPI()
-app.add_middleware(RateLimitMiddleware)
-app.add_middleware(BodySizeLimitMiddleware)
-app.add_middleware(
-  CORSMiddleware,
-  allow_origins=get_allowed_origins(),
-  allow_methods=["POST", "GET"],
-  allow_headers=["*"],
+
+def create_app(rate_limiter: RateLimiterProtocol) -> FastAPI:
+  app = FastAPI()
+  app.state.rate_limiter = rate_limiter
+  app.add_middleware(RateLimitMiddleware)
+  app.add_middleware(BodySizeLimitMiddleware)
+  app.add_middleware(
+    CORSMiddleware,
+    allow_origins=get_allowed_origins(),
+    allow_methods=["POST", "GET"],
+    allow_headers=["*"],
+  )
+  app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1"])
+  app.middleware("http")(set_security_headers)
+  app.middleware("http")(log_requests)
+  app.middleware("http")(add_correlation_id)
+
+  @app.on_event("startup")
+  async def startup_event() -> None:
+    reload_schema()
+    await validate_environment()
+
+  app.include_router(chat.router)
+  app.include_router(pdf.router)
+  app.include_router(health.router)
+  return app
+
+
+rate_limiter = RedisRateLimiter(
+  redis_client, RATE_LIMIT, RATE_WINDOW, FALLBACK_IP_TTL, FALLBACK_MAX_IPS
 )
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1"])
-app.middleware("http")(set_security_headers)
-app.middleware("http")(log_requests)
-app.middleware("http")(add_correlation_id)
+app = create_app(rate_limiter)
 
-
-@app.on_event("startup")
-async def startup_event() -> None:
-  reload_schema()
-  await validate_environment()
-
-
-app.include_router(chat.router)
-app.include_router(pdf.router)
-app.include_router(health.router)


### PR DESCRIPTION
## Summary
- add `create_app` factory with injectable rate limiter
- refactor `RateLimitMiddleware` to read `app.state.rate_limiter`
- update tests to supply in-memory limiter through the factory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae0a134ad48332ab4f375e2489de78