### PR TITLE
feat: add global error boundary

### DIFF
--- a/frontend/src/lib/components/ErrorBoundary.svelte
+++ b/frontend/src/lib/components/ErrorBoundary.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { writable } from 'svelte/store'
+
+  const error = writable<Error | null>(null)
+
+  function reload() {
+    location.reload()
+  }
+
+  onMount(() => {
+    const handleError = (event: ErrorEvent) => {
+      console.error(event.error || event.message)
+      error.set(event.error || new Error(event.message))
+    }
+    const handleRejection = (event: PromiseRejectionEvent) => {
+      console.error(event.reason)
+      const err =
+        event.reason instanceof Error
+          ? event.reason
+          : new Error(String(event.reason))
+      error.set(err)
+    }
+    window.addEventListener('error', handleError)
+    window.addEventListener('unhandledrejection', handleRejection)
+    return () => {
+      window.removeEventListener('error', handleError)
+      window.removeEventListener('unhandledrejection', handleRejection)
+    }
+  })
+</script>
+
+{#if $error}
+  <div class="p-4 text-center">
+    <p class="mb-2">Something went wrong.</p>
+    <button class="bg-blue-500 text-white px-3 py-1 rounded" on:click={reload}>
+      Reload
+    </button>
+  </div>
+{:else}
+  <slot />
+{/if}
+

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,9 @@
 <script>
   import '../app.css'
+  import ErrorBoundary from '$lib/components/ErrorBoundary.svelte'
 </script>
 
-<slot />
+<ErrorBoundary>
+  <slot />
+</ErrorBoundary>
+


### PR DESCRIPTION
## Summary
- add ErrorBoundary.svelte to capture global errors and unhandled rejections
- wrap root layout with ErrorBoundary

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0c35d4b08332ad5be33325b0be08