### PR TITLE
feat: add offline service worker

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,12 @@
 <script>
   import '../app.css'
+  import { onMount } from 'svelte'
+
+  onMount(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/service-worker.js')
+    }
+  })
 </script>
 
 <slot />

--- a/frontend/src/routes/offline/+page.svelte
+++ b/frontend/src/routes/offline/+page.svelte
@@ -1,0 +1,3 @@
+<h1>Offline</h1>
+<p>You appear to be offline. Please reconnect to continue.</p>
+

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -1,0 +1,124 @@
+/// <reference lib="webworker" />
+
+const CACHE = 'podrafter-cache-v1'
+const QUEUE = 'api-queue'
+const OFFLINE_URL = '/offline'
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(['/', OFFLINE_URL]))
+  )
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('fetch', event => {
+  const request = event.request
+
+  if (request.method !== 'GET') {
+    event.respondWith(handleNonGet(request))
+    return
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match(OFFLINE_URL))
+    )
+    return
+  }
+
+  event.respondWith(fetchAndCache(request))
+})
+
+self.addEventListener('sync', event => {
+  if (event.tag === QUEUE) {
+    event.waitUntil(sendQueued())
+  }
+})
+
+async function fetchAndCache(request: Request) {
+  try {
+    const response = await fetch(request)
+    const cache = await caches.open(CACHE)
+    cache.put(request, response.clone())
+    return response
+  } catch {
+    const cached = await caches.match(request)
+    if (cached) return cached
+    if (request.mode === 'navigate') return caches.match(OFFLINE_URL)
+    throw new Error('Network error')
+  }
+}
+
+async function handleNonGet(request: Request) {
+  try {
+    return await fetch(request.clone())
+  } catch {
+    const body = await request.clone().json().catch(() => null)
+    await saveRequest({ url: request.url, method: request.method, body })
+    await self.registration.sync.register(QUEUE)
+    return new Response(JSON.stringify({ queued: true }), {
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+}
+
+interface QueuedRequest {
+  url: string
+  method: string
+  body: any
+}
+
+function openDB() {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open('bg-sync', 1)
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(QUEUE, { autoIncrement: true })
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+async function saveRequest(data: QueuedRequest) {
+  const db = await openDB()
+  const tx = db.transaction(QUEUE, 'readwrite')
+  tx.objectStore(QUEUE).add(data)
+  return new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}
+
+async function sendQueued() {
+  const db = await openDB()
+  const tx = db.transaction(QUEUE, 'readwrite')
+  const store = tx.objectStore(QUEUE)
+  const all = store.getAll()
+  const keys = store.getAllKeys()
+  await new Promise((resolve, reject) => {
+    all.onsuccess = resolve
+    all.onerror = reject
+  })
+  await new Promise((resolve, reject) => {
+    keys.onsuccess = resolve
+    keys.onerror = reject
+  })
+  const requests = all.result.map((data, i) => ({ key: keys.result[i], data }))
+  for (const { key, data } of requests) {
+    await fetch(data.url, {
+      method: data.method,
+      headers: { 'Content-Type': 'application/json' },
+      body: data.body ? JSON.stringify(data.body) : undefined
+    })
+    store.delete(key)
+  }
+  return new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}
+


### PR DESCRIPTION
## Summary
- add service worker with caching, offline fallback, and background sync queueing
- register service worker in root layout
- add offline page for network outages

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: CACError: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0cb51ca88332ab0a234ae2024444