### PR TITLE
feat: harden security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ For local development, set both `CHAT_API_KEY` and `PUBLIC_CHAT_API_KEY` in `.en
 
 The backend rejects bodies larger than `MAX_REQUEST_SIZE` (10 KB). Requests declaring a larger `Content-Length` receive a **413**. For chunked or streaming requests without `Content-Length`, the body is read incrementally and processing stops once the limit is exceeded, returning **413**.
 
+### Security headers
+
+The backend sends a strict Content Security Policy restricting all resource types to the same origin:
+
+```
+default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'none'
+```
+
+No external origins are required by default. If `PUBLIC_API_BASE_URL` points to another domain or you load assets from a CDN, include those origins in the relevant directives (e.g. `connect-src`).
+
+Additional headers:
+
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: no-referrer`
+- `Permissions-Policy: geolocation=(), microphone=(), camera=()`
+- `X-Content-Type-Options: nosniff`
+
 ### Installing Test Dependencies
 
 Install Python packages for the micro‑service and Node packages for the SvelteKit front‑end before running tests.

--- a/backend/middleware/security.py
+++ b/backend/middleware/security.py
@@ -43,8 +43,20 @@ class BodySizeLimitMiddleware(BaseHTTPMiddleware):
 
 async def set_security_headers(request: Request, call_next):
   response = await call_next(request)
-  response.headers["Content-Security-Policy"] = "default-src 'self'"
+  csp = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self'; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "font-src 'self'; "
+    "frame-ancestors 'none'"
+  )
+  response.headers["Content-Security-Policy"] = csp
   response.headers["X-Content-Type-Options"] = "nosniff"
+  response.headers["X-Frame-Options"] = "DENY"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
   return response
 
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -38,8 +38,23 @@ def test_security_headers(path):
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
         resp = await client.get(path)
-    assert resp.headers["content-security-policy"] == "default-src 'self'"
+    expected_csp = (
+        "default-src 'self'; "
+        "script-src 'self'; "
+        "style-src 'self'; "
+        "img-src 'self' data:; "
+        "connect-src 'self'; "
+        "font-src 'self'; "
+        "frame-ancestors 'none'"
+    )
+    assert resp.headers["content-security-policy"] == expected_csp
     assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["x-frame-options"] == "DENY"
+    assert resp.headers["referrer-policy"] == "no-referrer"
+    assert (
+        resp.headers["permissions-policy"]
+        == "geolocation=(), microphone=(), camera=()"
+    )
 
   asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- add explicit CSP directives for scripts, styles, images, connections, and fonts
- include X-Frame-Options, Referrer-Policy, and Permissions-Policy headers
- document security headers and guidance for external origins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae0d8c26b08332a3e26e0ed640104c