### PR TITLE
feat: add route-specific rate limiting

### DIFF
--- a/backend/api/pdf.py
+++ b/backend/api/pdf.py
@@ -4,6 +4,7 @@ from fastapi.responses import StreamingResponse
 from jsonschema import ValidationError, validate, FormatChecker
 
 from ..middleware.auth import verify_api_key
+from ..middleware.rate_limit import rate_limit
 from ..services.pdf_service import generate_pdf
 from ..utils.validation import MAX_REQUEST_SIZE, MAX_FIELD_LENGTH, PETITION_SCHEMA
 from ..worker import queue
@@ -12,6 +13,7 @@ router = APIRouter()
 
 
 @router.post("/pdf")
+@rate_limit(limit=5, window=60, key="pdf")
 async def pdf(data: dict, request: Request) -> StreamingResponse:
   verify_api_key(request)
 


### PR DESCRIPTION
## Summary
- implement keyed rate_limit decorator with remaining quota headers
- apply stricter limits to /pdf endpoint
- expose rate limiter state in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae0f4b398c8332bb8d86b124560d19