### PR TITLE
feat: add static asset service worker and escape cleanup

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -68,6 +68,14 @@
     })
     pdfUrl.set(null)
     appState.set({ currentStep: 'chat', isLoading: false })
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(regs =>
+        regs.forEach(r => r.unregister())
+      )
+    }
+    if ('caches' in window) {
+      caches.keys().then(keys => keys.forEach(k => caches.delete(k)))
+    }
     window.location.href = 'https://www.google.com'
   }
 </script>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,13 @@
-<script>
+<script lang="ts">
   import '../app.css'
   import ErrorBoundary from '$lib/components/ErrorBoundary.svelte'
+  import { onMount } from 'svelte'
+
+  onMount(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/service-worker.js')
+    }
+  })
 </script>
 
 <ErrorBoundary>

--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -1,0 +1,35 @@
+const STATIC_CACHE = 'static-v1'
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== STATIC_CACHE).map((k) => caches.delete(k)),
+        ),
+      ),
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return
+  const url = new URL(event.request.url)
+  const isStatic =
+    url.origin === self.location.origin &&
+    /\.(css|js|png|jpg|jpeg|svg|gif|ico)$/.test(url.pathname)
+  if (!isStatic) return
+  event.respondWith(
+    caches.open(STATIC_CACHE).then(async (cache) => {
+      const cached = await cache.match(event.request)
+      if (cached) return cached
+      const response = await fetch(event.request)
+      cache.put(event.request, response.clone())
+      return response
+    }),
+  )
+})


### PR DESCRIPTION
## Summary
- cache only static files via service worker
- register service worker on layout
- clear caches and service worker on Quick Escape

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68ae2fe81cac8332862e71cafb23e088