### PR TITLE
fix: namespace PDF API route

### DIFF
--- a/backend/api/pdf.py
+++ b/backend/api/pdf.py
@@ -19,7 +19,7 @@ PDF_LATENCY = Histogram(
 )
 
 
-@router.post("/pdf")
+@router.post("/api/pdf")
 @rate_limit(limit=5, window=60, key="pdf")
 async def pdf(data: dict, request: Request) -> StreamingResponse:
   verify_api_key(request)

--- a/backend/middleware/security.py
+++ b/backend/middleware/security.py
@@ -9,7 +9,7 @@ from .auth import get_client_ip
 from ..utils.validation import MAX_REQUEST_SIZE
 
 logger = structlog.get_logger(__name__)
-SENSITIVE_PATHS = {"/api/chat", "/pdf"}
+SENSITIVE_PATHS = {"/api/chat", "/api/pdf"}
 
 
 class BodySizeLimitMiddleware(BaseHTTPMiddleware):

--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -38,7 +38,7 @@ def test_chunked_request_too_large():
       transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
       resp = await client.post(
-        "/pdf",
+        "/api/pdf",
         content=gen(),
         headers={
           "Content-Type": "application/json",

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -141,7 +141,7 @@ def test_pdf_generation(monkeypatch):
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
         resp = await client.post(
-            "/pdf", json=data, headers={"X-API-Key": "test-key"}
+            "/api/pdf", json=data, headers={"X-API-Key": "test-key"}
         )
     assert resp.status_code == 200
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
@@ -176,7 +176,7 @@ def test_pdf_missing_api_key():
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-        resp = await client.post("/pdf", json=data)
+        resp = await client.post("/api/pdf", json=data)
     assert resp.status_code == 401
 
   asyncio.run(_run())
@@ -198,7 +198,7 @@ def test_pdf_invalid_api_key():
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
         resp = await client.post(
-            "/pdf", json=data, headers={"X-API-Key": "wrong"}
+            "/api/pdf", json=data, headers={"X-API-Key": "wrong"}
         )
     assert resp.status_code == 401
 
@@ -395,7 +395,7 @@ def test_pdf_invalid_schema():
         transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
         resp = await client.post(
-            "/pdf", json=data, headers={"X-API-Key": "test-key"}
+            "/api/pdf", json=data, headers={"X-API-Key": "test-key"}
         )
     assert resp.status_code == 400
 

--- a/backend/tests/test_pdf_queue.py
+++ b/backend/tests/test_pdf_queue.py
@@ -62,7 +62,7 @@ def test_route_enqueues_and_returns_zip(monkeypatch):
     async with httpx.AsyncClient(
       transport=httpx.ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-      return await client.post("/pdf", json=data, headers={"X-API-Key": "test-key"})
+      return await client.post("/api/pdf", json=data, headers={"X-API-Key": "test-key"})
 
   resp = asyncio.run(_run())
   assert resp.status_code == 200

--- a/frontend/tests/generatePDF.test.ts
+++ b/frontend/tests/generatePDF.test.ts
@@ -22,7 +22,7 @@ describe('generatePDF', () => {
     const resp = await generatePDF({} as PetitionData)
     expect(resp.success).toBe(true)
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.any(String),
+      '/api/pdf',
       expect.objectContaining({
         headers: expect.objectContaining({ 'X-API-Key': 'test-key' }),
       }),


### PR DESCRIPTION
## Summary
- scope backend PDF route under `/api`
- update security middleware and tests for new PDF path
- ensure Svelte `generatePDF` uses `/api/pdf`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*
- `npm test -- --watchAll=false` *(fails: CACError: Unknown option `--watchAll`)*

------
https://chatgpt.com/codex/tasks/task_b_68ae31880e688332bff2542dbe3d0d46