### PR TITLE
fix: remove public chat API key fallback

### DIFF
--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -1,13 +1,13 @@
 import os
 from fastapi import HTTPException, Request
 
-CHAT_API_KEY = os.getenv("CHAT_API_KEY") or os.getenv("PUBLIC_CHAT_API_KEY")
+CHAT_API_KEY = os.getenv("CHAT_API_KEY")
+if CHAT_API_KEY is None:
+  raise HTTPException(status_code=500, detail="Server misconfiguration")
 
 
 def verify_api_key(request: Request) -> None:
   provided = request.headers.get("X-API-Key")
-  if CHAT_API_KEY is None:
-    raise HTTPException(status_code=500, detail="Server misconfiguration")
   if not provided or provided != CHAT_API_KEY:
     raise HTTPException(status_code=401, detail="Unauthorized")
 

--- a/backend/tests/test_chat_key_fallback.py
+++ b/backend/tests/test_chat_key_fallback.py
@@ -1,62 +1,14 @@
-import asyncio
-import httpx
 import importlib
 import pytest
-from openai.resources.chat.completions import AsyncCompletions
+from fastapi import HTTPException
 
 
-class DummyRedis:
-  async def zremrangebyscore(self, *args, **kwargs):
-    pass
-
-  async def zcard(self, *args, **kwargs):
-    return 0
-
-  async def zadd(self, *args, **kwargs):
-    pass
-
-  async def expire(self, *args, **kwargs):
-    pass
-
-
-@pytest.fixture
-def app(monkeypatch):
+def test_public_key_without_chat_key_fails(monkeypatch):
   monkeypatch.setenv("OPENAI_API_KEY", "test")
   monkeypatch.delenv("CHAT_API_KEY", raising=False)
   monkeypatch.setenv("PUBLIC_CHAT_API_KEY", "test-key")
-  import backend.main as main
-  importlib.reload(main)
-  monkeypatch.setattr("backend.main.redis_client", DummyRedis())
-  return main.app
-
-
-def test_public_key_fallback(monkeypatch, app):
-  async def fake_create(self, *args, **kwargs):
-    class Msg:
-      role = "assistant"
-      content = "hi"
-      tool_calls = []
-
-      def model_dump(self):
-        return {"role": self.role, "content": self.content}
-
-    class Choice:
-      message = Msg()
-
-    class Resp:
-      choices = [Choice()]
-
-    return Resp()
-
-  async def _run():
-    monkeypatch.setattr(AsyncCompletions, "create", fake_create)
-    async with httpx.AsyncClient(
-      transport=httpx.ASGITransport(app=app), base_url="http://testserver"
-    ) as client:
-      resp = await client.post(
-        "/api/chat", json={"messages": []}, headers={"X-API-Key": "test-key"}
-      )
-    assert resp.status_code == 200
-
-  asyncio.run(_run())
-
+  with pytest.raises(HTTPException) as exc:
+    import backend.main as main
+    importlib.reload(main)
+  assert exc.value.status_code == 500
+  assert exc.value.detail == "Server misconfiguration"


### PR DESCRIPTION
## Summary
- require CHAT_API_KEY to be present and drop PUBLIC_CHAT_API_KEY fallback
- adjust tests to fail when only PUBLIC_CHAT_API_KEY is set

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'structlog')*


------
https://chatgpt.com/codex/tasks/task_b_68ae34a4f5b083328cf204b85930b599