### PR TITLE
fix: sanitize county clerk address

### DIFF
--- a/backend/templates/cover_letter.html
+++ b/backend/templates/cover_letter.html
@@ -67,7 +67,7 @@
   </div>
 
   <div class="clerk-info">
-    <p>{{ county_clerk_address | e | replace('\n', '<br>' | safe) | safe }}</p>
+    <p>{{ county_clerk_address | e | replace('\n', '<br>' | safe) }}</p>
   </div>
 
   <p>Re: <strong>{{ petitioner_full_name }}</strong> v. <strong>{{ respondent_full_name }}</strong></p>


### PR DESCRIPTION
## Summary
- remove unsafe filter from county clerk address template

## Testing
- `pytest backend/tests/test_template_sanitization.py::test_county_clerk_address_escaped -q` *(fails: No module named 'structlog')*
- `pytest backend/tests -q` *(fails: No module named 'structlog')*


------
https://chatgpt.com/codex/tasks/task_b_68ae36235074833293f22b923fb36371