### PR TITLE
fix: restrict CORS headers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ def create_app(rate_limiter: RateLimiterProtocol) -> FastAPI:
     CORSMiddleware,
     allow_origins=get_allowed_origins(),
     allow_methods=["POST", "GET"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "X-API-Key"],
   )
   app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1"])
   app.middleware("http")(set_security_headers)


### PR DESCRIPTION
## Summary
- limit CORS allowed headers to Content-Type and X-API-Key

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'structlog')*


------
https://chatgpt.com/codex/tasks/task_b_68ae3744f8ec8332a5c429fd8fb8c270