### PR TITLE
test: verify template checksum integrity

### DIFF
--- a/backend/services/template_service.py
+++ b/backend/services/template_service.py
@@ -20,6 +20,8 @@ FIELD_MAP = {
   "respondent_full_name": "RespondentName",
 }
 
+# Pre-computed SHA-256 checksums for the standard PDF templates.
+# These values are used to verify the integrity of form templates at runtime.
 TEMPLATE_CHECKSUMS: dict[str, str] = {
   "dallas.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",
   "harris.pdf": "fd8584654ccf09fa6b9628fd8fd9859cc6cdc18e566b9a4b3db1f136f821b2c8",

--- a/backend/tests/test_template_checksums.py
+++ b/backend/tests/test_template_checksums.py
@@ -1,9 +1,15 @@
 import os
 import hashlib
+import pytest
+from fastapi import HTTPException
 
 os.environ["OPENAI_API_KEY"] = "test"
 
-from backend.main import TEMPLATE_CHECKSUMS, FORMS_DIR
+from backend.services.template_service import (
+  TEMPLATE_CHECKSUMS,
+  FORMS_DIR,
+  verify_template_integrity,
+)
 
 
 def test_template_checksums():
@@ -12,3 +18,10 @@ def test_template_checksums():
     with open(path, "rb") as f:
       expected[path.name] = hashlib.sha256(f.read()).hexdigest()
   assert TEMPLATE_CHECKSUMS == expected
+
+
+def test_verify_template_integrity_raises_on_mismatch(monkeypatch):
+  path = next(FORMS_DIR.glob("*.pdf"))
+  monkeypatch.setitem(TEMPLATE_CHECKSUMS, path.name, "badchecksum")
+  with pytest.raises(HTTPException):
+    verify_template_integrity(path)


### PR DESCRIPTION
## Summary
- document template checksums for standard PDF forms
- add test to ensure checksum mismatches raise HTTPException

## Testing
- `pytest` *(fails: No module named 'structlog')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement structlog==24.1.0)*

------
https://chatgpt.com/codex/tasks/task_b_68ae3d8e874883329fc986536ac68aa9