### PR TITLE
fix: strip HTML tags and attributes

### DIFF
--- a/backend/tests/test_xss_sanitization.py
+++ b/backend/tests/test_xss_sanitization.py
@@ -16,6 +16,8 @@ from backend.main import sanitize_string, app
     ("<img src=x onerror=alert(1)>", ""),
     ("javascript:alert(1)", "alert(1)"),
     ("data:text/html,<script>alert(1)</script>", "text/html,alert(1)"),
+    ("<b>bold</b>", "bold"),
+    ("<a href='https://example.com' onclick='alert(1)'>link</a>", "link"),
   ],
 )
 def test_sanitize_string(payload, expected):

--- a/backend/utils/sanitization.py
+++ b/backend/utils/sanitization.py
@@ -13,7 +13,7 @@ DISALLOWED_PATTERNS = [
 
 
 def sanitize_string(value: str) -> str:
-  cleaned = bleach.clean(value, strip=True)
+  cleaned = bleach.clean(value, tags=[], attributes={}, strip=True)
   cleaned = re.sub(r"[\x00-\x1f\x7f-\x9f]", "", cleaned)
   cleaned = re.sub(r"(javascript:|data:)", "", cleaned, flags=re.IGNORECASE)
   return cleaned.strip()[:MAX_FIELD_LENGTH]


### PR DESCRIPTION
## Summary
- strip all HTML tags and attributes in `sanitize_string`
- broaden XSS sanitization tests for allowed/disallowed HTML cases

## Testing
- `pytest` *(fails: test_public_key_without_chat_key_fails, test_chat_truncates_history)*
- `pytest backend/tests/test_xss_sanitization.py::test_sanitize_string -q`


------
https://chatgpt.com/codex/tasks/task_b_68af423bd41083328135fe8dc54108b3