### PR TITLE
fix: validate chat api key at startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import Response
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from .api import chat, pdf, health
+from .middleware.auth import validate_api_key
 from .middleware.rate_limit import (
   RateLimitMiddleware,
   redis_client,
@@ -52,6 +53,7 @@ def create_app(rate_limiter: RateLimiterProtocol) -> FastAPI:
   async def startup_event() -> None:
     reload_schema()
     await validate_environment()
+    validate_api_key()
 
   app.include_router(chat.router)
   app.include_router(pdf.router)

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -2,8 +2,11 @@ import os
 from fastapi import HTTPException, Request
 
 CHAT_API_KEY = os.getenv("CHAT_API_KEY")
-if CHAT_API_KEY is None:
-  raise HTTPException(status_code=500, detail="Server misconfiguration")
+
+
+def validate_api_key() -> None:
+  if CHAT_API_KEY is None:
+    raise RuntimeError("CHAT_API_KEY is not set")
 
 
 def verify_api_key(request: Request) -> None:

--- a/backend/tests/test_chat_key_fallback.py
+++ b/backend/tests/test_chat_key_fallback.py
@@ -1,6 +1,5 @@
 import importlib
 import pytest
-from fastapi import HTTPException
 
 
 def test_public_key_without_chat_key_fails(monkeypatch):
@@ -8,9 +7,9 @@ def test_public_key_without_chat_key_fails(monkeypatch):
   monkeypatch.delenv("CHAT_API_KEY", raising=False)
   monkeypatch.setenv("PUBLIC_CHAT_API_KEY", "test-key")
   import backend.middleware.auth as auth
-  with pytest.raises(HTTPException) as exc:
-    importlib.reload(auth)
-  assert exc.value.status_code == 500
-  assert exc.value.detail == "Server misconfiguration"
+  importlib.reload(auth)
+  with pytest.raises(RuntimeError):
+    auth.validate_api_key()
   monkeypatch.setenv("CHAT_API_KEY", "test-key")
   importlib.reload(auth)
+  auth.validate_api_key()


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when CHAT_API_KEY is missing via new `validate_api_key`
- call `validate_api_key` during application startup
- adjust tests for new API key validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af895fc084833299f957ffa2b33e87