### PR TITLE
refactor: reuse max field length constant

### DIFF
--- a/backend/utils/sanitization.py
+++ b/backend/utils/sanitization.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import bleach
 from pydantic import BaseModel, field_validator
 
-MAX_FIELD_LENGTH = 1000
+from .validation import MAX_FIELD_LENGTH
 
 DISALLOWED_PATTERNS = [
   re.compile(p, re.IGNORECASE)


### PR DESCRIPTION
## Summary
- reuse `MAX_FIELD_LENGTH` from `validation` module in `sanitization`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af8d202ce08332806c517a693aecdb