### PR TITLE
fix: remove redundant catch in sendChat

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -40,8 +40,6 @@ export async function sendChat(
     }
     const json = (await res.json()) as ChatResponse
     return json
-  } catch (err) {
-    throw err
   } finally {
     clearTimeout(timer)
   }


### PR DESCRIPTION
## Summary
- remove unnecessary catch block and rely on try/finally to clear chat timeout

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68af962d30e88332b1377643d72ab44a