### PR TITLE
feat: purge client storage on quick escape

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -76,6 +76,13 @@
     if ('caches' in window) {
       caches.keys().then(keys => keys.forEach(k => caches.delete(k)))
     }
+    // Clear browser storage to remove any persisted data
+    if ('localStorage' in window) {
+      localStorage.clear()
+    }
+    if ('sessionStorage' in window) {
+      sessionStorage.clear()
+    }
     window.location.href = 'https://www.google.com'
   }
 </script>

--- a/frontend/tests/quickEscape.test.ts
+++ b/frontend/tests/quickEscape.test.ts
@@ -1,0 +1,47 @@
+import { render, fireEvent } from '@testing-library/svelte'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { get } from 'svelte/store'
+import AppLayout from '../src/lib/components/AppLayout.svelte'
+import { chatMessages, petitionData, pdfUrl, appState } from '../src/lib/stores'
+
+const defaultPetition = {
+  county: 'General',
+  petitioner_full_name: '',
+  respondent_full_name: ''
+}
+
+const originalLocation = window.location
+
+describe('quickEscape', () => {
+  beforeEach(() => {
+    chatMessages.set([{ role: 'user', content: 'hi' }])
+    petitionData.set({
+      county: 'Test',
+      petitioner_full_name: 'A',
+      respondent_full_name: 'B'
+    })
+    pdfUrl.set('http://example.com')
+    appState.set({ currentStep: 'download', isLoading: true })
+    localStorage.setItem('foo', 'bar')
+    sessionStorage.setItem('baz', 'qux')
+    Object.defineProperty(window, 'location', { writable: true, value: { href: '' } })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { writable: true, value: originalLocation })
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('clears all client-side data', async () => {
+    const { getByText } = render(AppLayout)
+    await fireEvent.click(getByText('Quick Escape'))
+
+    expect(localStorage.length).toBe(0)
+    expect(sessionStorage.length).toBe(0)
+    expect(get(chatMessages)).toEqual([])
+    expect(get(petitionData)).toEqual(defaultPetition)
+    expect(get(pdfUrl)).toBeNull()
+    expect(get(appState)).toEqual({ currentStep: 'chat', isLoading: false })
+  })
+})


### PR DESCRIPTION
## Summary
- clear localStorage and sessionStorage in quick escape flow
- test quick escape resets stores and browser storage

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68afb44bdbf88332a38e2b137ccdc986