### PR TITLE
feat: add warm theme tokens and ui components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.10",
     "@sveltejs/kit": "^2.5.0",
     "@sveltejs/adapter-vercel": "^5.3.0",
     "@testing-library/jest-dom": "^6.4.2",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,6 +1,9 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@import './lib/styles/tokens.css';
+@import './lib/styles/components.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 html {
   font-family: system-ui, sans-serif;

--- a/frontend/src/lib/components/ui/Button.svelte
+++ b/frontend/src/lib/components/ui/Button.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  export let variant: 'primary' | 'ghost' | 'danger' = 'primary'
+  export let size: 'sm' | 'md' | 'lg' = 'md'
+  export let loading = false
+  export let type: 'button' | 'submit' | 'reset' = 'button'
+  export let disabled = false
+</script>
+<button class={`btn btn-${variant} ${size !== 'md' ? 'btn-'+size : ''} ${loading ? 'opacity-80 cursor-wait' : ''}`}
+  {type} disabled={disabled || loading} aria-busy={loading}>
+  <slot />
+</button>

--- a/frontend/src/lib/components/ui/Card.svelte
+++ b/frontend/src/lib/components/ui/Card.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let hover = false
+  export let padded = true
+</script>
+<section class={`card ${hover ? 'hover' : ''}`}>
+  <header class="px-4 pt-4 pb-2"><slot name="header"/></header>
+  <div class={`${padded ? 'p-4' : ''}`}><slot/></div>
+  {#if $$slots.footer}<footer class="px-4 pt-2 pb-4"><slot name="footer"/></footer>{/if}
+</section>

--- a/frontend/src/lib/components/ui/Input.svelte
+++ b/frontend/src/lib/components/ui/Input.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  export let id = crypto.randomUUID()
+  export let label = ''
+  export let type = 'text'
+  export let value: string | number | undefined
+  export let placeholder = ''
+  export let help = ''
+  export let error = ''
+  export let required = false
+</script>
+<div class="space-y-1.5">
+  {#if label}<label class="block text-sm font-medium text-gray-700" for={id}>
+    {label}{#if required}<span class="text-red-500"> *</span>{/if}
+  </label>{/if}
+  <input class={`input ${error ? 'input-error' : ''}`} {id} {type} {placeholder} {required} bind:value />
+  {#if error}<p class="text-xs text-red-600">{error}</p>
+  {:else if help}<p class="text-xs text-gray-500">{help}</p>{/if}
+</div>

--- a/frontend/src/lib/components/ui/Navbar.svelte
+++ b/frontend/src/lib/components/ui/Navbar.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  export let title = ''
+  let open = false
+</script>
+<nav class="navbar">
+  <div class="mx-auto max-w-7xl px-4">
+    <div class="flex h-14 items-center justify-between">
+      <div class="flex items-center gap-3"><slot name="logo"/>{#if title}<h1 class="text-sm font-semibold">{title}</h1>{/if}</div>
+      <div class="hidden md:flex items-center gap-2"><slot name="actions"/></div>
+      <button class="md:hidden btn btn-ghost btn-sm" on:click={() => open = !open} aria-expanded={open}>Menu</button>
+    </div>
+    {#if open}<div class="md:hidden py-2 border-t" style="border-color:var(--color-border)"><slot name="actions"/></div>{/if}
+  </div>
+</nav>

--- a/frontend/src/lib/components/ui/ProgressBar.svelte
+++ b/frontend/src/lib/components/ui/ProgressBar.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  export let value = 0
+  export let color: 'primary' | 'success' | 'warning' | 'error' = 'primary'
+  const map = {primary:'var(--color-terra)',success:'var(--color-success)',warning:'var(--color-warning)',error:'var(--color-error)'} as const
+</script>
+<div class="w-full h-2 rounded-full" style="background: color-mix(in srgb, var(--color-border) 60%, transparent);">
+  <div class="h-2 rounded-full transition-all" style={`width:${Math.max(0,Math.min(100,value))}%; background:${map[color]};`}/>
+</div>

--- a/frontend/src/lib/styles/components.css
+++ b/frontend/src/lib/styles/components.css
@@ -1,0 +1,94 @@
+@layer base {
+  :root {
+    font-size: var(--t-base);
+  }
+  body {
+    background: var(--color-bg);
+    color: var(--color-text);
+  }
+}
+@layer components {
+  .card {
+    @apply rounded-lg border;
+    background: var(--color-surface);
+    border-color: var(--color-border);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow var(--dur-base) var(--ease);
+  }
+  .card:hover {
+    box-shadow: var(--shadow-md);
+  }
+
+  .btn {
+    @apply inline-flex items-center justify-center font-semibold select-none px-4 py-2 border;
+    border-radius: var(--radius-md);
+    transition:
+      background var(--dur-fast) var(--ease),
+      transform var(--dur-fast) var(--ease),
+      box-shadow var(--dur-fast) var(--ease);
+  }
+  .btn:active {
+    transform: translateY(1px);
+  }
+  .btn-primary {
+    color: #fff;
+    background: var(--color-primary);
+    border-color: transparent;
+  }
+  .btn-primary:hover {
+    background: var(--color-primary-600);
+    box-shadow: var(--shadow-sm);
+  }
+  .btn-ghost {
+    background: transparent;
+    color: var(--color-text);
+    border-color: var(--color-border);
+  }
+  .btn-ghost:hover {
+    background: rgba(0, 0, 0, 0.035);
+  }
+  .btn-danger {
+    color: #fff;
+    background: var(--color-error);
+    border-color: transparent;
+  }
+  .btn-sm {
+    @apply text-sm px-3 py-1.5;
+  }
+  .btn-lg {
+    @apply text-base px-5 py-3;
+  }
+
+  .input {
+    @apply w-full rounded-md border px-3 py-2 text-sm outline-none;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+    transition:
+      border-color var(--dur-fast) var(--ease),
+      box-shadow var(--dur-fast) var(--ease);
+  }
+  .input:focus {
+    border-color: var(--color-primary);
+    box-shadow: var(--focus-ring);
+  }
+  .input-error {
+    border-color: var(--color-error);
+  }
+
+  .badge {
+    @apply inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium;
+    background: color-mix(in srgb, var(--color-accent) 16%, white);
+    color: #8b2d30;
+  }
+
+  .navbar {
+    @apply w-full sticky top-0 z-20 border-b backdrop-blur;
+    background: color-mix(in srgb, var(--color-surface) 85%, transparent);
+    border-color: var(--color-border);
+  }
+
+  .row:hover {
+    background: var(--color-rose);
+  }
+}

--- a/frontend/src/lib/styles/tokens.css
+++ b/frontend/src/lib/styles/tokens.css
@@ -1,0 +1,44 @@
+:root {
+  --color-bg: #f9fafb;
+  --color-surface: #ffffff;
+  --color-elevated: #ffffff;
+  --color-text: #1f2937;
+  --color-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-primary: #5b3653;
+  --color-primary-600: #4a2e45;
+  --color-accent: #f16667;
+  --color-terra: #d08b6b;
+  --color-rose: rgba(208, 143, 163, 0.1);
+  --color-success: #10b981;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --focus-ring: 0 0 0 3px
+    color-mix(in srgb, var(--color-accent) 35%, transparent);
+
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.1);
+
+  --t-base: 16px;
+  --t-scale: 1.25;
+  --ease: cubic-bezier(0.2, 0, 0, 1);
+  --dur-fast: 150ms;
+  --dur-base: 200ms;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #0b1220;
+    --color-surface: #0f172a;
+    --color-elevated: #111827;
+    --color-text: #e5e7eb;
+    --color-muted: #9ca3af;
+    --color-border: #1f2937;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.45);
+    --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.55);
+  }
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,8 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{html,js,svelte,ts}'],
+  content: ['./src/**/*.{svelte,ts,js}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: { primary: 'var(--color-primary)' },
+      borderRadius: { md: 'var(--radius-md)', lg: 'var(--radius-lg)' },
+      boxShadow: { card: 'var(--shadow-sm)' }
+    }
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')]
 }


### PR DESCRIPTION
## Summary
- centralize styling via CSS tokens and component layer imports
- extend Tailwind config with warm palette variables and form/typography plugins
- add UI primitives (Button, Input, Card, Navbar, ProgressBar) using new warm theme

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fforms)*
- `npm test -- --watchAll=false` *(fails: CACError: Unknown option `--watchAll`)*
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68afb6fc0c008332803674aa779a87ee