### PR TITLE
feat: bound worker queue and reject excess enqueues

### DIFF
--- a/backend/tests/test_worker_queue_limit.py
+++ b/backend/tests/test_worker_queue_limit.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+from fastapi import HTTPException
+
+from backend.worker import WorkerQueue
+
+
+def test_excessive_enqueues_rejected():
+  queue = WorkerQueue()
+  queue._queue = asyncio.Queue(maxsize=1)
+  queue._worker_started = True
+
+  async def dummy():
+    return None
+
+  async def run():
+    await queue.enqueue(dummy)
+    with pytest.raises(HTTPException) as exc:
+      await queue.enqueue(dummy)
+    assert exc.value.status_code == 503
+
+  asyncio.run(run())


### PR DESCRIPTION
## Summary
- cap worker queue at 100 tasks and raise HTTP 503 when full
- add test verifying queue rejects excessive enqueues

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b0b3ad570083328a4555daf7651863