### PR TITLE
chore: pin openai SDK version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==2.6.4
 fastapi==0.110.0
 uvicorn==0.29.0
-openai>=1.0.0,<2.0.0
+openai==1.12.0
 jsonschema==4.21.1
 PyPDF2==3.0.1
 jinja2==3.1.3


### PR DESCRIPTION
## Summary
- pin openai requirement to version 1.12.0

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai==1.12.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b0c136c71c8332adc1a823adfaa83b