### PR TITLE
feat: show active step instructions

### DIFF
--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -10,6 +10,7 @@
   import { WIZARD_STEPS } from '$lib/constants'
   import { generatePDF, canProceedToReview } from '$lib/utils'
   import { get } from 'svelte/store'
+  import type { WizardStep } from '$lib/types'
 
   let ChatArea: typeof import('./ChatArea.svelte').default | null = null
   let ProgressSidebar: typeof import('./ProgressSidebar.svelte').default | null = null
@@ -17,7 +18,15 @@
 
   let revokePdf: (() => void) | null = null
 
+  const STEP_INSTRUCTIONS: Record<WizardStep, string> = {
+    chat: 'Share your story to get started.',
+    review: 'Review the details and make any edits.',
+    generate: 'Generate your petition document.',
+    download: 'Download your completed petition.'
+  }
+
   $: canReview = canProceedToReview($petitionData)
+  $: activeStep = WIZARD_STEPS.find(({ step }) => step === $appState.currentStep)
 
   $: if ($appState.currentStep === 'chat' && (!ChatArea || !ProgressSidebar)) {
     Promise.all([
@@ -108,6 +117,13 @@
     </span>
   {/each}
 </nav>
+
+  <h2 class="text-lg font-semibold mb-1">
+    {activeStep?.title}
+  </h2>
+  <p class="mb-4 text-gray-600">
+    {STEP_INSTRUCTIONS[$appState.currentStep]}
+  </p>
 
   {#if $appState.currentStep === 'chat'}
     <div class="md:flex gap-4">


### PR DESCRIPTION
## Summary
- show current wizard step title and instructions

## Testing
- `npm test -- --watchAll=false` *(fails: CACError Unknown option `--watchAll`)*
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68b0d2f77f048332bd0bd2dbf7e52fc3