### PR TITLE
feat: add tooltips to progress sidebar

### DIFF
--- a/frontend/src/lib/components/ProgressSidebar.svelte
+++ b/frontend/src/lib/components/ProgressSidebar.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { petitionData } from '$lib/stores'
-  import { FIELD_DESCRIPTIONS } from '$lib/constants'
+  import { FIELD_DESCRIPTIONS, FIELD_LABELS } from '$lib/constants'
   import type { PetitionData } from '$lib/types'
   import {
     validatePetition,
     getCollectedFields,
     getNextSuggestedField
   } from '$lib/utils'
+  import Tooltip from './ui/Tooltip.svelte'
 
   $: validation = validatePetition($petitionData)
   $: fieldStatus = getCollectedFields($petitionData)
@@ -23,14 +24,34 @@
   </div>
   <p class="mt-1">{validation.completionPercentage}% complete</p>
   <ul class="mt-4 space-y-1">
-    {#each Object.entries(FIELD_DESCRIPTIONS) as [field, desc]}
+    {#each Object.keys(FIELD_LABELS) as field}
       <li class="flex items-center gap-2">
         {#if fieldStatus.collected.includes(field as keyof PetitionData)}
           <span class="text-green-600">✔</span>
         {:else}
           <span class="text-gray-400">✖</span>
         {/if}
-        <span>{desc}</span>
+        <span class="flex items-center gap-1">
+          {FIELD_LABELS[field as keyof PetitionData]}
+          <Tooltip content={FIELD_DESCRIPTIONS[field as keyof PetitionData]}>
+            <button type="button" class="text-gray-500 focus:outline-none">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                class="w-4 h-4"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zm1 8a1 1 0 100-2h-1V9a1 1 0 00-1-1H9a1 1 0 100 2h1v3H9a1 1 0 100 2h3z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              <span class="sr-only">Info about {FIELD_LABELS[field as keyof PetitionData]}</span>
+            </button>
+          </Tooltip>
+        </span>
       </li>
     {/each}
   </ul>

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  export let content = ''
+</script>
+
+<span class="relative inline-block group">
+  <slot />
+  <span
+    role="tooltip"
+    class="pointer-events-none absolute left-1/2 top-full mt-1 -translate-x-1/2 rounded bg-gray-700 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+  >
+    {content}
+  </span>
+</span>
+


### PR DESCRIPTION
## Summary
- show field descriptions via tooltip icons in progress sidebar
- add reusable Svelte/Tailwind tooltip component

## Testing
- `npm test -- --watchAll=false` *(fails: Unknown option `--watchAll`)*
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68b1e090d13483328c78db8715d16433