### PR TITLE
feat: add field guidance to review form

### DIFF
--- a/frontend/src/lib/components/ReviewForm.svelte
+++ b/frontend/src/lib/components/ReviewForm.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import { petitionData, appState, prevStep, nextStep } from '$lib/stores'
-  import { FIELD_LABELS } from '$lib/constants'
+  import {
+    FIELD_LABELS,
+    FIELD_DESCRIPTIONS,
+    REQUIRED_FIELDS
+  } from '$lib/constants'
   import { validatePetition } from '$lib/utils'
   import { get } from 'svelte/store'
   import type { PetitionData } from '$lib/types'
+  import Tooltip from './ui/Tooltip.svelte'
 
   const fieldEntries: [keyof PetitionData, string][] = Object.entries(
     FIELD_LABELS
@@ -21,9 +26,42 @@
 </script>
 
 <div class="mb-4">
+  <h2 class="text-xl font-semibold mb-2">Review Details</h2>
+  <p class="mb-4">
+    Confirm the information below. Required fields are marked with an asterisk
+    (*)
+  </p>
   {#each fieldEntries as [field, label]}
     <div class="mb-2">
-      <label class="font-bold" for={`${field}-input`}>{label}</label>
+      <label
+        class="font-bold flex items-center gap-1"
+        for={`${field}-input`}
+      >
+        {label}
+        {#if REQUIRED_FIELDS.includes(field)}
+          <Tooltip content="Required field">
+            <span class="text-red-500" aria-hidden="true">*</span>
+          </Tooltip>
+        {/if}
+        <Tooltip content={FIELD_DESCRIPTIONS[field]}>
+          <button type="button" class="text-gray-500 focus:outline-none">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              class="w-4 h-4"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zm1 8a1 1 0 100-2h-1V9a1 1 0 00-1-1H9a1 1 0 100 2h1v3H9a1 1 0 100 2h3z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <span class="sr-only">Info about {label}</span>
+          </button>
+        </Tooltip>
+      </label>
       <input
         id={`${field}-input`}
         class="w-full border p-2 rounded"


### PR DESCRIPTION
## Summary
- add review heading and instructions
- flag required petition fields and explain via tooltip
- include info tooltips for every review field

## Testing
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_b_68b1e25957f88332a0fb4038da7d9c6b