### PR TITLE
feat: add quick escape info tooltip

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@sveltejs/adapter-vercel": "^5.3.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/svelte": "^4.0.4",
+    "@heroicons/svelte": "^2.0.18",
     "autoprefixer": "^10.4.0",
     "eslint": "^8.57.0",
     "jsdom": "^24.0.0",

--- a/frontend/src/lib/components/AppLayout.svelte
+++ b/frontend/src/lib/components/AppLayout.svelte
@@ -11,6 +11,8 @@
   import { generatePDF, canProceedToReview } from '$lib/utils'
   import { get } from 'svelte/store'
   import type { WizardStep } from '$lib/types'
+  import Tooltip from './ui/Tooltip.svelte'
+  import { InformationCircleIcon } from '@heroicons/svelte/24/outline'
 
   let ChatArea: typeof import('./ChatArea.svelte').default | null = null
   let ProgressSidebar: typeof import('./ProgressSidebar.svelte').default | null = null
@@ -102,6 +104,13 @@
 >
   Quick Escape
 </button>
+
+<Tooltip content="Immediately clears data and redirects to a safe site.">
+  <InformationCircleIcon
+    aria-label="Information about quick escape"
+    class="fixed top-2 right-28 z-50 h-6 w-6 text-gray-500"
+  />
+</Tooltip>
 
 <div class="mx-auto p-4 max-w-4xl">
   {#if $appState.error}


### PR DESCRIPTION
## Summary
- add tooltip with information icon explaining Quick Escape
- include @heroicons/svelte dependency for icons

## Testing
- `npm test -- --watchAll=false` (fails: Unknown option `--watchAll`)
- `npm test` (fails: Cannot convert undefined or null to object)


------
https://chatgpt.com/codex/tasks/task_b_68b21b856d6c8332a2af73dfa03600be